### PR TITLE
Fix scripts properties array

### DIFF
--- a/UtinyRipperCore/Parser/AssetCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoArray.cs
+++ b/UtinyRipperCore/Parser/AssetCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoArray.cs
@@ -1,0 +1,88 @@
+﻿using Mono.Cecil;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace UtinyRipper.Exporters.Scripts.Mono
+{
+	public sealed class ScriptExportMonoArray : ScriptExportArray
+	{
+		public ScriptExportMonoArray(TypeReference @type, TypeDefinition @definition)
+		{
+			if (@type == null || @definition == null)
+			{
+				throw new ArgumentNullException(nameof(@type));
+			}
+			if (!type.IsArray)
+			{
+				throw new Exception("Type isn't an array");
+			}
+
+			Type = @type;
+			Definition = @definition;
+		}
+
+		public override void Init(IScriptExportManager manager)
+		{
+			m_element = CreateElementType(manager);
+
+			m_module = Path.GetFileNameWithoutExtension(Type.Scope.Name);
+			m_fullName = $"[{Module}]{Type.FullName}";
+		}
+
+
+		public override ScriptExportType GetContainer(IScriptExportManager manager)
+		{
+			if (Type.IsNested)
+			{
+				return manager.RetrieveType(Type.DeclaringType);
+			}
+			else
+			{
+				return this;
+			}
+		}
+
+
+		private ScriptExportType CreateElementType(IScriptExportManager manager)
+		{
+			return manager.RetrieveType(Type.GetElementType());
+		}
+
+
+		protected override string Keyword
+		{
+			get
+			{
+				if (Definition.IsPublic || Definition.IsNestedPublic)
+				{
+					return PublicKeyWord;
+				}
+				if (Definition.IsNestedPrivate)
+				{
+					return PrivateKeyWord;
+				}
+				if (Definition.IsNestedFamily)
+				{
+					return ProtectedKeyWord;
+				}
+				return InternalKeyWord;
+			}
+		}
+
+
+		public override string FullName => m_fullName;
+		public override string Name => Type.Name;
+		public override string Namespace => Type.Namespace;
+		public override string Module => m_module;
+
+		protected override ScriptExportType Element => m_element;
+
+		private TypeReference Type { get; }
+		private TypeDefinition Definition { get; }
+
+		private ScriptExportType m_element;
+		private string m_fullName;
+		private string m_module;
+	}
+}

--- a/UtinyRipperCore/Parser/AssetCollection/Exporter/Exporters/Script/Elements/ScriptExportArray.cs
+++ b/UtinyRipperCore/Parser/AssetCollection/Exporter/Exporters/Script/Elements/ScriptExportArray.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace UtinyRipper.Exporters.Scripts
+{
+	public abstract class ScriptExportArray : ScriptExportType
+	{      
+		public override void GetUsedNamespaces(ICollection<string> namespaces)
+		{
+			GetTypeNamespaces(namespaces);
+			Element.GetTypeNamespaces(namespaces);
+		}
+
+		protected override ScriptExportType Base => null;
+
+		public override IReadOnlyList<ScriptExportType> GenericArguments { get; } = new ScriptExportType[0];
+		public override IReadOnlyList<ScriptExportType> NestedTypes { get; } = new ScriptExportType[0];
+		public override IReadOnlyList<ScriptExportEnum> NestedEnums { get; } = new ScriptExportEnum[0];
+		public override IReadOnlyList<ScriptExportDelegate> Delegates { get; } = new ScriptExportDelegate[0];
+		public override IReadOnlyList<ScriptExportField> Fields { get; } = new ScriptExportField[0];
+
+		protected abstract ScriptExportType Element { get; }
+
+		protected override bool IsStruct => false;
+		protected override bool IsSerializable => false;
+
+	}
+}

--- a/UtinyRipperCore/Parser/AssetCollection/Exporter/Exporters/Script/ScriptExportManager.cs
+++ b/UtinyRipperCore/Parser/AssetCollection/Exporter/Exporters/Script/ScriptExportManager.cs
@@ -118,6 +118,11 @@ namespace UtinyRipper.Exporters.Scripts
 		
 		public ScriptExportType RetrieveType(TypeReference type)
 		{
+			if (type.IsArray)
+			{
+				TypeDefinition definition = type.Resolve();
+				return RetrieveArray(type, definition);
+			}
 			if(type.Module != null)
 			{
 				TypeDefinition definition = type.Resolve();
@@ -133,7 +138,6 @@ namespace UtinyRipper.Exporters.Scripts
 					}
 				}
 			}
-
 			if (m_types.TryGetValue(type.FullName, out ScriptExportType exportType))
 			{
 				return exportType;
@@ -173,6 +177,13 @@ namespace UtinyRipper.Exporters.Scripts
 			ScriptExportField exportField = new ScriptExportMonoField(field);
 			exportField.Init(this);
 			return exportField;
+		}
+
+		public ScriptExportArray RetrieveArray(TypeReference type, TypeDefinition definition)
+		{
+			ScriptExportArray exportType = new ScriptExportMonoArray(type, definition);
+			exportType.Init(this);
+			return exportType;
 		}
 
 		public ScriptExportParameter RetrieveParameter(ParameterDefinition parameter)

--- a/UtinyRipperCore/UtinyRipperCore.csproj
+++ b/UtinyRipperCore/UtinyRipperCore.csproj
@@ -889,6 +889,8 @@
     <Compile Include="Utils\Logger\Logger.cs" />
     <Compile Include="Utils\Logger\LogType.cs" />
     <Compile Include="Utils\RandomUtils.cs" />
+    <Compile Include="Parser\AssetCollection\Exporter\Exporters\Script\Elements\Mono\ScriptExportMonoArray.cs" />
+    <Compile Include="Parser\AssetCollection\Exporter\Exporters\Script\Elements\ScriptExportArray.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />


### PR DESCRIPTION
When scripts had properties like "MyScriptClass[] ScriptList" the exporter was creating MyScriptClass[].cs files instead of MyScriptClass.cs . This will fix it