### PR TITLE
Resource folder structure recreation

### DIFF
--- a/uTinyRipperCore/Parser/Classes/ResourceManager/ResourceManager.cs
+++ b/uTinyRipperCore/Parser/Classes/ResourceManager/ResourceManager.cs
@@ -23,17 +23,17 @@ namespace uTinyRipper.Classes
 		}
 
 		public override void Read(AssetReader reader)
-        {
-            base.Read(reader);
+		{
+		    base.Read(reader);
 
-            m_container = reader.ReadStringTKVPArray<PPtr<Object>>();
-            if (IsReadDependentAssets(reader.Version, reader.Flags))
-            {
-                m_dependentAssets = reader.ReadAssetArray<ResourceManagerDependency>();
-            }
-        }
+		    m_container = reader.ReadStringTKVPArray<PPtr<Object>>();
+		    if (IsReadDependentAssets(reader.Version, reader.Flags))
+		    {
+			m_dependentAssets = reader.ReadAssetArray<ResourceManagerDependency>();
+		    }
+		}
 
-        public override IEnumerable<Object> FetchDependencies(ISerializedFile file, bool isLog = false)
+        	public override IEnumerable<Object> FetchDependencies(ISerializedFile file, bool isLog = false)
 		{
 			foreach (Object asset in base.FetchDependencies(file, isLog))
 			{
@@ -66,33 +66,33 @@ namespace uTinyRipper.Classes
 			return node;
 		}
 
-        public bool GetResourcePathFromAsset(Object asset, string filePath, ref string resourceSubFolder, ref string resourceFileName)
-        {
-            string assetsFolderLocation = filePath.Substring(0, filePath.LastIndexOf("Assets\\") + 7);
-            string exportedFileExtension = filePath.Substring(filePath.LastIndexOf("."));
+		public bool GetResourcePathFromAsset(Object asset, string filePath, ref string resourceSubFolder, ref string resourceFileName)
+		{
+		    string assetsFolderLocation = filePath.Substring(0, filePath.LastIndexOf("Assets\\") + 7);
+		    string exportedFileExtension = filePath.Substring(filePath.LastIndexOf("."));
 
-            foreach (KeyValuePair<string, PPtr<Object>> containerEntry in m_container)
-            {
-                try
-                {
-                    if (asset == containerEntry.Value.GetAsset(File)) // containerEntry.Key contains a basic path in lowercase (folder1/folder2/filename), containerEntry.Value is linked to the actual asset
-                    {
-                        string basicPath = "Resources/" + containerEntry.Key;
-                        string pathWithNoFileName = basicPath.Substring(0, basicPath.LastIndexOf('/') + 1);
-                        string resourceFileNameFromPath = basicPath.Substring(basicPath.LastIndexOf('/') + 1); // lacks an extension, we need to use it because sometimes it's different than the export name given to it
+		    foreach (KeyValuePair<string, PPtr<Object>> containerEntry in m_container)
+		    {
+			try
+			{
+			    if (asset == containerEntry.Value.GetAsset(File)) // containerEntry.Key contains a basic path in lowercase (folder1/folder2/filename), containerEntry.Value is linked to the actual asset
+			    {
+				string basicPath = "Resources/" + containerEntry.Key;
+				string pathWithNoFileName = basicPath.Substring(0, basicPath.LastIndexOf('/') + 1);
+				string resourceFileNameFromPath = basicPath.Substring(basicPath.LastIndexOf('/') + 1); // lacks an extension, we need to use it because sometimes it's different than the export name given to it
 
-                        resourceFileName = resourceFileNameFromPath + exportedFileExtension;
-                        resourceSubFolder = assetsFolderLocation + pathWithNoFileName;
+				resourceFileName = resourceFileNameFromPath + exportedFileExtension;
+				resourceSubFolder = assetsFolderLocation + pathWithNoFileName;
 
-                        return true; 
-                    }
-                } catch (System.Exception ex) // we might run into a "path ID x was not found" error (maybe unimplemented class?)
-                {
-                    continue;
-                }
-            }
-            return false;
-        }
+				return true; 
+			    }
+			} catch (System.Exception ex) // we might run into a "path ID x was not found" error (maybe unimplemented class?)
+			{
+			    continue;
+			}
+		    }
+		    return false;
+		}
 
 		public IReadOnlyList<KeyValuePair<string, PPtr<Object>>> Container => m_container;
 		public ILookup<string, PPtr<Object>> ContainerMap => Container.ToLookup(t => t.Key, t => t.Value);

--- a/uTinyRipperCore/Parser/Classes/ResourceManager/ResourceManager.cs
+++ b/uTinyRipperCore/Parser/Classes/ResourceManager/ResourceManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using uTinyRipper.AssetExporters;
 using uTinyRipper.Classes.ResourceManagers;
 using uTinyRipper.YAML;
@@ -24,16 +25,16 @@ namespace uTinyRipper.Classes
 
 		public override void Read(AssetReader reader)
 		{
-		    base.Read(reader);
+			base.Read(reader);
 
-		    m_container = reader.ReadStringTKVPArray<PPtr<Object>>();
-		    if (IsReadDependentAssets(reader.Version, reader.Flags))
-		    {
-			m_dependentAssets = reader.ReadAssetArray<ResourceManagerDependency>();
-		    }
+			m_container = reader.ReadStringTKVPArray<PPtr<Object>>();
+			if (IsReadDependentAssets(reader.Version, reader.Flags))
+			{
+				m_dependentAssets = reader.ReadAssetArray<ResourceManagerDependency>();
+			}
 		}
 
-        	public override IEnumerable<Object> FetchDependencies(ISerializedFile file, bool isLog = false)
+		public override IEnumerable<Object> FetchDependencies(ISerializedFile file, bool isLog = false)
 		{
 			foreach (Object asset in base.FetchDependencies(file, isLog))
 			{
@@ -66,32 +67,36 @@ namespace uTinyRipper.Classes
 			return node;
 		}
 
-		public bool GetResourcePathFromAsset(Object asset, string filePath, ref string resourceSubFolder, ref string resourceFileName)
+		public bool GetResourcePathFromAsset(Object asset, string filePath, out string resourcePath)
 		{
-		    string assetsFolderLocation = filePath.Substring(0, filePath.LastIndexOf("Assets\\") + 7);
-		    string exportedFileExtension = filePath.Substring(filePath.LastIndexOf("."));
+			string assetsFolderLocation = filePath.Substring(0, filePath.LastIndexOf("Assets") + 7);
+			string exportedFileExtension = Path.GetExtension(filePath);
 
-		    foreach (KeyValuePair<string, PPtr<Object>> containerEntry in m_container)
-		    {
-			try
+			foreach (KeyValuePair<string, PPtr<Object>> containerEntry in m_container)
 			{
-			    if (asset == containerEntry.Value.GetAsset(File)) // containerEntry.Key contains a basic path in lowercase (folder1/folder2/filename), containerEntry.Value is linked to the actual asset
-			    {
-				string basicPath = "Resources/" + containerEntry.Key;
-				string pathWithNoFileName = basicPath.Substring(0, basicPath.LastIndexOf('/') + 1);
-				string resourceFileNameFromPath = basicPath.Substring(basicPath.LastIndexOf('/') + 1); // lacks an extension, we need to use it because sometimes it's different than the export name given to it
+				try
+				{
+					if (containerEntry.Value.IsAsset(File, asset)) // containerEntry.Key contains a basic path in lowercase (folder1/folder2/filename), containerEntry.Value is linked to the actual asset
+					{
+						string assetsResourceDirectoryPath = "Resources/" + Path.GetDirectoryName(containerEntry.Key) + "/";
+						resourcePath = assetsFolderLocation + assetsResourceDirectoryPath + Path.GetFileName(filePath);
 
-				resourceFileName = resourceFileNameFromPath + exportedFileExtension;
-				resourceSubFolder = assetsFolderLocation + pathWithNoFileName;
+						if (System.IO.File.Exists(resourcePath)) // for some reason this situation can take place with font assets, we use the less "accurate" resourcePath file name
+						{
+							resourcePath = assetsResourceDirectoryPath + Path.GetFileName(containerEntry.Key) + exportedFileExtension;
+						}
 
-				return true; 
-			    }
-			} catch (System.Exception ex) // we might run into a "path ID x was not found" error (maybe unimplemented class?)
-			{
-			    continue;
+						return true;
+					}
+				}
+				catch (System.NotSupportedException ex)
+				{
+					// still having issues with exceptions, probably as a result of the iteration through a prefab's list of assets (only the second one appears to be identified)
+				}
 			}
-		    }
-		    return false;
+			resourcePath = string.Empty;
+
+			return false;
 		}
 
 		public IReadOnlyList<KeyValuePair<string, PPtr<Object>>> Container => m_container;

--- a/uTinyRipperCore/Parser/Classes/ResourceManager/ResourceManager.cs
+++ b/uTinyRipperCore/Parser/Classes/ResourceManager/ResourceManager.cs
@@ -23,17 +23,17 @@ namespace uTinyRipper.Classes
 		}
 
 		public override void Read(AssetReader reader)
-		{
-			base.Read(reader);
+        {
+            base.Read(reader);
 
-			m_container = reader.ReadStringTKVPArray<PPtr<Object>>();
-			if (IsReadDependentAssets(reader.Version, reader.Flags))
-			{
-				m_dependentAssets = reader.ReadAssetArray<ResourceManagerDependency>();
-			}
-		}
+            m_container = reader.ReadStringTKVPArray<PPtr<Object>>();
+            if (IsReadDependentAssets(reader.Version, reader.Flags))
+            {
+                m_dependentAssets = reader.ReadAssetArray<ResourceManagerDependency>();
+            }
+        }
 
-		public override IEnumerable<Object> FetchDependencies(ISerializedFile file, bool isLog = false)
+        public override IEnumerable<Object> FetchDependencies(ISerializedFile file, bool isLog = false)
 		{
 			foreach (Object asset in base.FetchDependencies(file, isLog))
 			{
@@ -65,6 +65,34 @@ namespace uTinyRipper.Classes
 			}
 			return node;
 		}
+
+        public bool GetResourcePathFromAsset(Object asset, string filePath, ref string resourceSubFolder, ref string resourceFileName)
+        {
+            string assetsFolderLocation = filePath.Substring(0, filePath.LastIndexOf("Assets\\") + 7);
+            string exportedFileExtension = filePath.Substring(filePath.LastIndexOf("."));
+
+            foreach (KeyValuePair<string, PPtr<Object>> containerEntry in m_container)
+            {
+                try
+                {
+                    if (asset == containerEntry.Value.GetAsset(File)) // containerEntry.Key contains a basic path in lowercase (folder1/folder2/filename), containerEntry.Value is linked to the actual asset
+                    {
+                        string basicPath = "Resources/" + containerEntry.Key;
+                        string pathWithNoFileName = basicPath.Substring(0, basicPath.LastIndexOf('/') + 1);
+                        string resourceFileNameFromPath = basicPath.Substring(basicPath.LastIndexOf('/') + 1); // lacks an extension, we need to use it because sometimes it's different than the export name given to it
+
+                        resourceFileName = resourceFileNameFromPath + exportedFileExtension;
+                        resourceSubFolder = assetsFolderLocation + pathWithNoFileName;
+
+                        return true; 
+                    }
+                } catch (System.Exception ex) // we might run into a "path ID x was not found" error (maybe unimplemented class?)
+                {
+                    continue;
+                }
+            }
+            return false;
+        }
 
 		public IReadOnlyList<KeyValuePair<string, PPtr<Object>>> Container => m_container;
 		public ILookup<string, PPtr<Object>> ContainerMap => Container.ToLookup(t => t.Key, t => t.Value);

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Collections/AssetExportCollection.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Collections/AssetExportCollection.cs
@@ -10,7 +10,7 @@ namespace uTinyRipper.AssetExporters
 {
 	public class AssetExportCollection : ExportCollection
 	{
-		public AssetExportCollection(IAssetExporter assetExporter, Object asset):
+		public AssetExportCollection(IAssetExporter assetExporter, Object asset) :
 			this(assetExporter, asset, new NativeFormatImporter(asset))
 		{
 		}
@@ -37,28 +37,27 @@ namespace uTinyRipper.AssetExporters
 		public override bool Export(ProjectAssetContainer container, string dirPath)
 		{
 			string subFolder = Asset.ExportName;
-				string subPath = Path.Combine(dirPath, subFolder);
-				string fileName = GetUniqueFileName(container.File, Asset, subPath);
-				string filePath = Path.Combine(subPath, fileName);
+			string subPath = Path.Combine(dirPath, subFolder);
+			string fileName = GetUniqueFileName(container.File, Asset, subPath);
+			string filePath = Path.Combine(subPath, fileName);
 
-			string resourceSubFolder = String.Empty;
-			string resourceFileName = String.Empty;
-			if (container.GetResourcePathFromAssets(Assets, filePath, ref resourceSubFolder, ref resourceFileName))
+			string resourcePath;
+			if (container.GetResourcePathFromAssets(Assets, filePath, out resourcePath))
 			{
-			subPath = resourceSubFolder;
-			filePath = resourceSubFolder + resourceFileName;
+				subPath = Path.GetDirectoryName(resourcePath);
+				filePath = resourcePath;
 			}
 
 			if (!DirectoryUtils.Exists(subPath))
-				{
-					DirectoryUtils.CreateVirtualDirectory(subPath);
-				}
+			{
+				DirectoryUtils.CreateVirtualDirectory(subPath);
+			}
 
 			if (ExportInner(container, filePath))
 			{
-			Meta meta = new Meta(MetaImporter, Asset.GUID);
-			ExportMeta(container, meta, filePath);
-			return true;
+				Meta meta = new Meta(MetaImporter, Asset.GUID);
+				ExportMeta(container, meta, filePath);
+				return true;
 			}
 			return false;
 		}
@@ -87,7 +86,7 @@ namespace uTinyRipper.AssetExporters
 
 		protected virtual bool ExportInner(ProjectAssetContainer container, string filePath)
 		{
-		    return AssetExporter.Export(container, Asset, filePath);
+			return AssetExporter.Export(container, Asset, filePath);
 		}
 
 		public override IAssetExporter AssetExporter { get; }

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Collections/AssetExportCollection.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Collections/AssetExportCollection.cs
@@ -35,31 +35,31 @@ namespace uTinyRipper.AssetExporters
 		}
 
 		public override bool Export(ProjectAssetContainer container, string dirPath)
-        {
-            string subFolder = Asset.ExportName;
-			string subPath = Path.Combine(dirPath, subFolder);
-			string fileName = GetUniqueFileName(container.File, Asset, subPath);
-			string filePath = Path.Combine(subPath, fileName);
+		{
+			string subFolder = Asset.ExportName;
+				string subPath = Path.Combine(dirPath, subFolder);
+				string fileName = GetUniqueFileName(container.File, Asset, subPath);
+				string filePath = Path.Combine(subPath, fileName);
 
-            string resourceSubFolder = String.Empty;
-            string resourceFileName = String.Empty;
-            if (container.GetResourcePathFromAssets(Assets, filePath, ref resourceSubFolder, ref resourceFileName))
-            {
-                subPath = resourceSubFolder;
-                filePath = resourceSubFolder + resourceFileName;
-            }
-
-            if (!DirectoryUtils.Exists(subPath))
+			string resourceSubFolder = String.Empty;
+			string resourceFileName = String.Empty;
+			if (container.GetResourcePathFromAssets(Assets, filePath, ref resourceSubFolder, ref resourceFileName))
 			{
-				DirectoryUtils.CreateVirtualDirectory(subPath);
+			subPath = resourceSubFolder;
+			filePath = resourceSubFolder + resourceFileName;
 			}
 
-            if (ExportInner(container, filePath))
-            {
-                Meta meta = new Meta(MetaImporter, Asset.GUID);
-                ExportMeta(container, meta, filePath);
-                return true;
-            }
+			if (!DirectoryUtils.Exists(subPath))
+				{
+					DirectoryUtils.CreateVirtualDirectory(subPath);
+				}
+
+			if (ExportInner(container, filePath))
+			{
+			Meta meta = new Meta(MetaImporter, Asset.GUID);
+			ExportMeta(container, meta, filePath);
+			return true;
+			}
 			return false;
 		}
 
@@ -86,8 +86,8 @@ namespace uTinyRipper.AssetExporters
 		}
 
 		protected virtual bool ExportInner(ProjectAssetContainer container, string filePath)
-        {
-            return AssetExporter.Export(container, Asset, filePath);
+		{
+		    return AssetExporter.Export(container, Asset, filePath);
 		}
 
 		public override IAssetExporter AssetExporter { get; }

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Collections/AssetExportCollection.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Collections/AssetExportCollection.cs
@@ -35,23 +35,31 @@ namespace uTinyRipper.AssetExporters
 		}
 
 		public override bool Export(ProjectAssetContainer container, string dirPath)
-		{
-			string subFolder = Asset.ExportName;
+        {
+            string subFolder = Asset.ExportName;
 			string subPath = Path.Combine(dirPath, subFolder);
 			string fileName = GetUniqueFileName(container.File, Asset, subPath);
 			string filePath = Path.Combine(subPath, fileName);
 
-			if (!DirectoryUtils.Exists(subPath))
+            string resourceSubFolder = String.Empty;
+            string resourceFileName = String.Empty;
+            if (container.GetResourcePathFromAssets(Assets, filePath, ref resourceSubFolder, ref resourceFileName))
+            {
+                subPath = resourceSubFolder;
+                filePath = resourceSubFolder + resourceFileName;
+            }
+
+            if (!DirectoryUtils.Exists(subPath))
 			{
 				DirectoryUtils.CreateVirtualDirectory(subPath);
 			}
 
-			if (ExportInner(container, filePath))
-			{
-				Meta meta = new Meta(MetaImporter, Asset.GUID);
-				ExportMeta(container, meta, filePath);
-				return true;
-			}
+            if (ExportInner(container, filePath))
+            {
+                Meta meta = new Meta(MetaImporter, Asset.GUID);
+                ExportMeta(container, meta, filePath);
+                return true;
+            }
 			return false;
 		}
 
@@ -78,8 +86,8 @@ namespace uTinyRipper.AssetExporters
 		}
 
 		protected virtual bool ExportInner(ProjectAssetContainer container, string filePath)
-		{
-			return AssetExporter.Export(container, Asset, filePath);
+        {
+            return AssetExporter.Export(container, Asset, filePath);
 		}
 
 		public override IAssetExporter AssetExporter { get; }

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/ProjectAssetContainer.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/ProjectAssetContainer.cs
@@ -44,10 +44,10 @@ namespace uTinyRipper.AssetExporters
 						m_tagManager = (TagManager)asset;
 						break;
                         
-                    case ClassIDType.ResourceManager:
-                        m_resourceManager = (ResourceManager)asset;
-                        break;
-                }
+					case ClassIDType.ResourceManager:
+						m_resourceManager = (ResourceManager)asset;
+						break;
+				}
 			}
 
 			List<SceneExportCollection> scenes = new List<SceneExportCollection>();
@@ -66,17 +66,17 @@ namespace uTinyRipper.AssetExporters
 			m_scenes = scenes.ToArray();
 		}
 
-        public bool GetResourcePathFromAssets(IEnumerable<Object> assets, string filePath, ref string resourceSubFolder, ref string resourceFileName)
-        {
-            foreach (Object asset in assets)
-            {
-                if (m_resourceManager.GetResourcePathFromAsset(asset, filePath, ref resourceSubFolder, ref resourceFileName))
-                    return true;
-            }
-            return false;
-        }
+		public bool GetResourcePathFromAssets(IEnumerable<Object> assets, string filePath, ref string resourceSubFolder, ref string resourceFileName)
+		{
+		    foreach (Object asset in assets)
+		    {
+			if (m_resourceManager.GetResourcePathFromAsset(asset, filePath, ref resourceSubFolder, ref resourceFileName))
+			    return true;
+		    }
+		    return false;
+		}
 
-        public Object FindAsset(int fileIndex, long pathID)
+		public Object FindAsset(int fileIndex, long pathID)
 		{
 			if(fileIndex == VirtualSerializedFile.VirtualFileIndex)
 			{
@@ -237,8 +237,8 @@ namespace uTinyRipper.AssetExporters
 
 		private readonly BuildSettings m_buildSettings;
 		private readonly TagManager m_tagManager;
-        private readonly ResourceManager m_resourceManager;
-        private readonly SceneExportCollection[] m_scenes;
+		private readonly ResourceManager m_resourceManager;
+		private readonly SceneExportCollection[] m_scenes;
 		private readonly TransferInstructionFlags m_exportFlags;
 	}
 }

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/ProjectAssetContainer.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/ProjectAssetContainer.cs
@@ -66,14 +66,18 @@ namespace uTinyRipper.AssetExporters
 			m_scenes = scenes.ToArray();
 		}
 
-		public bool GetResourcePathFromAssets(IEnumerable<Object> assets, string filePath, ref string resourceSubFolder, ref string resourceFileName)
+		public bool GetResourcePathFromAssets(IEnumerable<Object> assets, string filePath, out string resourcePath)
 		{
-		    foreach (Object asset in assets)
-		    {
-			if (m_resourceManager.GetResourcePathFromAsset(asset, filePath, ref resourceSubFolder, ref resourceFileName))
-			    return true;
-		    }
-		    return false;
+			foreach (Object asset in assets) // prefabs have a list of assets, would be better to just send the one that gets recognised if possible
+			{
+				if (m_resourceManager.GetResourcePathFromAsset(asset, filePath, out resourcePath))
+				{
+					return true;
+				}
+			}
+			resourcePath = string.Empty;
+
+			return false;
 		}
 
 		public Object FindAsset(int fileIndex, long pathID)

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/ProjectAssetContainer.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/ProjectAssetContainer.cs
@@ -43,7 +43,11 @@ namespace uTinyRipper.AssetExporters
 					case ClassIDType.TagManager:
 						m_tagManager = (TagManager)asset;
 						break;
-				}
+                        
+                    case ClassIDType.ResourceManager:
+                        m_resourceManager = (ResourceManager)asset;
+                        break;
+                }
 			}
 
 			List<SceneExportCollection> scenes = new List<SceneExportCollection>();
@@ -62,7 +66,17 @@ namespace uTinyRipper.AssetExporters
 			m_scenes = scenes.ToArray();
 		}
 
-		public Object FindAsset(int fileIndex, long pathID)
+        public bool GetResourcePathFromAssets(IEnumerable<Object> assets, string filePath, ref string resourceSubFolder, ref string resourceFileName)
+        {
+            foreach (Object asset in assets)
+            {
+                if (m_resourceManager.GetResourcePathFromAsset(asset, filePath, ref resourceSubFolder, ref resourceFileName))
+                    return true;
+            }
+            return false;
+        }
+
+        public Object FindAsset(int fileIndex, long pathID)
 		{
 			if(fileIndex == VirtualSerializedFile.VirtualFileIndex)
 			{
@@ -223,7 +237,8 @@ namespace uTinyRipper.AssetExporters
 
 		private readonly BuildSettings m_buildSettings;
 		private readonly TagManager m_tagManager;
-		private readonly SceneExportCollection[] m_scenes;
+        private readonly ResourceManager m_resourceManager;
+        private readonly SceneExportCollection[] m_scenes;
 		private readonly TransferInstructionFlags m_exportFlags;
 	}
 }


### PR DESCRIPTION
With these changes the resource folder structure is recreated automatically, even though everything is lower case due to the way Unity stores paths.