### PR TITLE
Fix exporting non-int enum types.

### DIFF
--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoEnum.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoEnum.cs
@@ -50,6 +50,7 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 			{
 				if (field.Name == "value__")
 				{
+                    m_BaseType = manager.RetrieveType(field.FieldType);
 					continue;
 				}
 
@@ -59,7 +60,9 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 			return fields;
 		}
 
-		public override string NestedName { get; }
+
+        public override ScriptExportType Base => m_BaseType;
+        public override string NestedName { get; }
 		public override string CleanNestedName { get; }
 		public override string TypeName => Type.Name;
 		public override string FullName { get; }
@@ -97,7 +100,8 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 		private TypeReference Type { get; }
 		private TypeDefinition Definition { get; }
 
-		private ScriptExportType m_declaringType;
+        private ScriptExportType m_BaseType;
+        private ScriptExportType m_declaringType;
 		private IReadOnlyList<ScriptExportField> m_fields;
 	}
 }

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportEnum.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportEnum.cs
@@ -10,7 +10,7 @@ namespace uTinyRipper.Exporters.Scripts
 			writer.WriteIndent(intent);
             writer.Write("{0} enum {1}", Keyword, TypeName);
             if (Base != null && Base.TypeName != "int") {
-                writer.Write(" : {2}", Base.TypeName);
+                writer.Write(" : {0}", Base.TypeName);
             }
             writer.WriteLine();
 

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportEnum.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportEnum.cs
@@ -8,7 +8,11 @@ namespace uTinyRipper.Exporters.Scripts
 		public sealed override void Export(TextWriter writer, int intent)
 		{
 			writer.WriteIndent(intent);
-			writer.WriteLine("{0} enum {1}", Keyword, TypeName);
+            writer.Write("{0} enum {1}", Keyword, TypeName);
+            if (Base != null && Base.TypeName != "int") {
+                writer.Write(" : {2}", Base.TypeName);
+            }
+            writer.WriteLine();
 
 			writer.WriteIndent(intent++);
 			writer.WriteLine('{');
@@ -29,7 +33,7 @@ namespace uTinyRipper.Exporters.Scripts
 
 		public sealed override bool IsEnum => true;
 
-		public sealed override ScriptExportType Base => null;
+		public override ScriptExportType Base => null;
 
 		protected sealed override bool IsStruct => throw new NotSupportedException();
 		protected sealed override bool IsSerializable => false;


### PR DESCRIPTION
Fix the export type of enums with a non-default size, such as long flag enums with more then 32 entries.