### PR TITLE
Fix monobehaviours treating System.Guid as serializable

### DIFF
--- a/uTinyRipperCore/Parser/FileCollection/Assembly/Mono/MonoField.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Assembly/Mono/MonoField.cs
@@ -133,8 +133,11 @@ namespace uTinyRipper.Assembly.Mono
 			{
 				return true;
 			}
-
 			if (MonoType.IsObject(fieldType))
+			{
+				return false;
+			}
+			if (MonoType.IsGuid(fieldType))
 			{
 				return false;
 			}

--- a/uTinyRipperCore/Parser/FileCollection/Assembly/Mono/MonoType.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Assembly/Mono/MonoType.cs
@@ -58,6 +58,10 @@ namespace uTinyRipper.Assembly.Mono
 		{
 			return IsObject(type.Namespace, type.Name);
 		}
+		public static bool IsGuid(TypeReference type)
+		{
+			return IsGuid(type.Namespace, type.Name);
+		}
 		public static bool IsString(TypeReference type)
 		{
 			return IsString(type.Namespace, type.Name);

--- a/uTinyRipperCore/Parser/FileCollection/Assembly/Serializable/SerializableType.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Assembly/Serializable/SerializableType.cs
@@ -103,6 +103,10 @@ namespace uTinyRipper.Assembly
 		{
 			return @namespace == SystemNamespace && (name == MonoUtils.ObjectName || name == MonoUtils.CObjectName);
 		}
+		public static bool IsGuid(string @namespace, string name)
+		{
+			return @namespace == SystemNamespace && name == MonoUtils.GuidName;
+		}
 		public static bool IsString(string @namespace, string name)
 		{
 			return @namespace == SystemNamespace && (name == MonoUtils.StringName || name == MonoUtils.CStringName);

--- a/uTinyRipperCore/Utils/MonoUtils.cs
+++ b/uTinyRipperCore/Utils/MonoUtils.cs
@@ -298,6 +298,7 @@ namespace uTinyRipper
 
 		public const string ObjectName = "Object";
 		public const string CObjectName = "object";
+		public const string GuidName = "Guid";
 		public const string ValueType = "ValueType";
 		public const string VoidName = "Void";
 		public const string CVoidName = "void";


### PR DESCRIPTION
Unity doesn't serialize System.Guid, but UtinyRipper acts as if it does. If a class contains a public System.Guid, UtinyRipper will throw the following error.
```
Read 220 but expected 216 for asset type MonoBehaviour
```
I'm wondering if this is limited to System.Guid, or other types marked serializable are ignored by unity.