### PR TITLE
Fix script export errors

### DIFF
--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/IScriptExportManager.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/IScriptExportManager.cs
@@ -10,10 +10,14 @@ namespace uTinyRipper.Exporters.Scripts
 		ScriptExportDelegate RetrieveDelegate(TypeDefinition type);
 		ScriptExportAttribute RetrieveAttribute(CustomAttribute attribute);
 		ScriptExportField RetrieveField(FieldDefinition field);
+		ScriptExportMethod RetrieveMethod(MethodDefinition method);
+		ScriptExportProperty RetrieveProperty(PropertyDefinition property);
 		ScriptExportParameter RetrieveParameter(ParameterDefinition parameter);
 
 		IEnumerable<ScriptExportType> Types { get; }
 		IEnumerable<ScriptExportEnum> Enums { get; }
 		IEnumerable<ScriptExportDelegate> Delegates { get; }
+		ICollection<string> TypeNames { get; }
+		ICollection<string> Namespaces { get; }
 	}
 }

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoArray.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoArray.cs
@@ -26,6 +26,7 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 		
 		public override void Init(IScriptExportManager manager)
 		{
+			base.Init(manager);
 			TypeSpecification specification = (TypeSpecification)Type;
 			m_element = manager.RetrieveType(specification.ElementType);
 		}
@@ -46,5 +47,7 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 		private TypeReference Type { get; }
 		
 		private ScriptExportType m_element;
+
+		public override bool IsPrimative => Element.IsPrimative;
 	}
 }

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoDelegate.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoDelegate.cs
@@ -30,11 +30,12 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 			{
 				return false;
 			}
-			return type.Namespace == SystemName && type.BaseType.Name == MulticastDelegateName;
+			return type.BaseType.Namespace == SystemName && type.BaseType.Name == MulticastDelegateName;
 		}
 
 		public override void Init(IScriptExportManager manager)
 		{
+			base.Init(manager);
 			m_return = CreateReturnType(manager);
 			m_parameters = CreateParameterTypes(manager);
 
@@ -109,5 +110,7 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 		private ScriptExportType m_declaringType;
 		private ScriptExportType m_return;
 		private IReadOnlyList<ScriptExportParameter> m_parameters;
+
+		public override bool IsPrimative => false;
 	}
 }

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoEnum.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoEnum.cs
@@ -27,6 +27,7 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 
 		public override void Init(IScriptExportManager manager)
 		{
+			base.Init(manager);
 			if (Type.Module == null)
 			{
 				m_fields = new ScriptExportField[0];
@@ -103,5 +104,7 @@ namespace uTinyRipper.Exporters.Scripts.Mono
         private ScriptExportType m_BaseType;
         private ScriptExportType m_declaringType;
 		private IReadOnlyList<ScriptExportField> m_fields;
+
+		public override bool IsPrimative => false;
 	}
 }

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoEnum.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoEnum.cs
@@ -50,6 +50,7 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 			{
 				if (field.Name == "value__")
 				{
+                    m_BaseType = manager.RetrieveType(field.FieldType);
 					continue;
 				}
 
@@ -59,7 +60,9 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 			return fields;
 		}
 
-		public override string NestedName { get; }
+
+        public override ScriptExportType Base => m_BaseType;
+        public override string NestedName { get; }
 		public override string CleanNestedName { get; }
 		public override string TypeName => Type.Name;
 		public override string FullName { get; }
@@ -97,7 +100,8 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 		private TypeReference Type { get; }
 		private TypeDefinition Definition { get; }
 
-		private ScriptExportType m_declaringType;
+        private ScriptExportType m_BaseType;
+        private ScriptExportType m_declaringType;
 		private IReadOnlyList<ScriptExportField> m_fields;
 	}
 }

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoField.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoField.cs
@@ -98,7 +98,7 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 				}
 				if (Field.IsAssembly)
 				{
-					return ProtectedKeyWord;
+					return InternalKeyWord;
 				}
 				return ProtectedKeyWord;
 			}

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoGeneric.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoGeneric.cs
@@ -28,6 +28,7 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 
 		public override void Init(IScriptExportManager manager)
 		{
+			base.Init(manager);
 			m_owner = manager.RetrieveType(Type.ElementType);
 
 			int argumentCount = MonoUtils.GetGenericArgumentCount(Type);
@@ -72,6 +73,8 @@ namespace uTinyRipper.Exporters.Scripts.Mono
 		public override string TypeName { get; }
 		public override string Namespace => Type.Namespace;
 		public override string Module { get; }
+
+		public override bool IsPrimative => false;
 
 		private GenericInstanceType Type { get; }
 

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoMethod.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoMethod.cs
@@ -1,0 +1,65 @@
+﻿using Mono.Cecil;
+using System;
+using System.Collections.Generic;
+
+namespace uTinyRipper.Exporters.Scripts.Mono
+{
+	public sealed class ScriptExportMonoMethod : ScriptExportMethod
+	{
+		public ScriptExportMonoMethod(MethodDefinition method)
+		{
+			if (method == null)
+			{
+				throw new ArgumentNullException(nameof(method));
+			}
+
+			Method = method;
+		}
+
+		public override void Init(IScriptExportManager manager)
+		{
+			m_declaringType = manager.RetrieveType(Method.DeclaringType);
+			m_returnType = manager.RetrieveType(Method.ReturnType);
+			int argumentCount = Method.Parameters.Count;
+			m_parameters = new ScriptExportParameter[argumentCount];
+			for (int i = 0; i < argumentCount; i++)
+			{
+				ParameterDefinition argument = Method.Parameters[i];
+				m_parameters[i] = manager.RetrieveParameter(argument);
+			}
+		}
+
+		public override string Name => Method.IsConstructor ? Method.DeclaringType.Name : Method.Name;
+		protected override bool IsOverride => true;
+		protected override string Keyword
+		{
+			get
+			{
+				if (Method.IsPublic)
+				{
+					return PublicKeyWord;
+				}
+				if (Method.IsPrivate)
+				{
+					return PrivateKeyWord;
+				}
+				if (Method.IsAssembly)
+				{
+					return ProtectedKeyWord;
+				}
+				return ProtectedKeyWord;
+			}
+		}
+
+		public override ScriptExportType DeclaringType => m_declaringType;
+		public override ScriptExportType ReturnType => m_returnType;
+		public override IReadOnlyList<ScriptExportParameter> Parameters => m_parameters;
+
+
+		private MethodDefinition Method { get; }
+
+		private ScriptExportType m_declaringType;
+		private ScriptExportParameter[] m_parameters;
+		private ScriptExportType m_returnType;
+	}
+}

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoProperty.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/Mono/ScriptExportMonoProperty.cs
@@ -1,0 +1,84 @@
+﻿using Mono.Cecil;
+using System;
+
+namespace uTinyRipper.Exporters.Scripts.Mono
+{
+	public sealed class ScriptExportMonoProperty: ScriptExportProperty
+	{
+		public ScriptExportMonoProperty(PropertyDefinition property)
+		{
+			if (property == null)
+			{
+				throw new ArgumentNullException(nameof(property));
+			}
+
+			Property = property;
+		}
+
+		public override void Init(IScriptExportManager manager)
+		{
+			m_declaringType = manager.RetrieveType(Property.DeclaringType);
+			m_propertyType = manager.RetrieveType(Property.PropertyType);
+		}
+
+		public override string Name => Property.Name;
+		protected override bool IsOverride => true;
+		protected override string GetKeyword
+		{
+			get
+			{
+				if (!HasGetter)
+				{
+					return "";
+				}
+				if (Property.GetMethod.IsPublic)
+				{
+					return PublicKeyWord;
+				}
+				if (Property.GetMethod.IsPrivate)
+				{
+					return PrivateKeyWord;
+				}
+				if (Property.GetMethod.IsAssembly)
+				{
+					return ProtectedKeyWord;
+				}
+				return ProtectedKeyWord;
+			}
+		}
+		protected override string SetKeyword
+		{
+			get
+			{
+				if(!HasSetter)
+				{
+					return "";
+				}
+				if (Property.SetMethod.IsPublic)
+				{
+					return PublicKeyWord;
+				}
+				if (Property.SetMethod.IsPrivate)
+				{
+					return PrivateKeyWord;
+				}
+				if (Property.SetMethod.IsAssembly)
+				{
+					return ProtectedKeyWord;
+				}
+				return ProtectedKeyWord;
+			}
+		}
+
+		protected override bool HasGetter => Property.GetMethod != null;
+		protected override bool HasSetter => Property.SetMethod != null;
+		public override ScriptExportType DeclaringType => m_declaringType;
+		public override ScriptExportType PropertyType => m_propertyType;
+
+
+		private PropertyDefinition Property { get; }
+
+		private ScriptExportType m_declaringType;
+		private ScriptExportType m_propertyType;
+	}
+}

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportArray.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportArray.cs
@@ -17,6 +17,8 @@ namespace uTinyRipper.Exporters.Scripts
 		public abstract ScriptExportType Element { get; }
 
 		public sealed override IReadOnlyList<ScriptExportField> Fields { get; } = new ScriptExportField[0];
+		public sealed override IReadOnlyList<ScriptExportProperty> Properties { get; } = new ScriptExportProperty[0];
+		public sealed override IReadOnlyList<ScriptExportMethod> Methods { get; } = new ScriptExportMethod[0];
 
 		protected sealed override string Keyword => throw new NotSupportedException();
 

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportDelegate.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportDelegate.cs
@@ -41,6 +41,8 @@ namespace uTinyRipper.Exporters.Scripts
 
 		public sealed override ScriptExportType Base => null;
 		public sealed override IReadOnlyList<ScriptExportField> Fields { get; } = new ScriptExportField[0];
+		public sealed override IReadOnlyList<ScriptExportProperty> Properties { get; } = new ScriptExportProperty[0];
+		public sealed override IReadOnlyList<ScriptExportMethod> Methods { get; } = new ScriptExportMethod[0];
 		public abstract ScriptExportType Return { get; }
 		public abstract IReadOnlyList<ScriptExportParameter> Parameters { get; }
 

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportEnum.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportEnum.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace uTinyRipper.Exporters.Scripts
@@ -32,6 +33,8 @@ namespace uTinyRipper.Exporters.Scripts
 		}
 
 		public sealed override bool IsEnum => true;
+		public sealed override IReadOnlyList<ScriptExportProperty> Properties { get; } = new ScriptExportProperty[0];
+		public sealed override IReadOnlyList<ScriptExportMethod> Methods { get; } = new ScriptExportMethod[0];
 
 		public override ScriptExportType Base => null;
 

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportEnum.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportEnum.cs
@@ -8,7 +8,11 @@ namespace uTinyRipper.Exporters.Scripts
 		public sealed override void Export(TextWriter writer, int intent)
 		{
 			writer.WriteIndent(intent);
-			writer.WriteLine("{0} enum {1}", Keyword, TypeName);
+            writer.Write("{0} enum {1}", Keyword, TypeName);
+            if (Base != null && Base.TypeName != "int") {
+                writer.Write(" : {0}", Base.TypeName);
+            }
+            writer.WriteLine();
 
 			writer.WriteIndent(intent++);
 			writer.WriteLine('{');
@@ -29,7 +33,7 @@ namespace uTinyRipper.Exporters.Scripts
 
 		public sealed override bool IsEnum => true;
 
-		public sealed override ScriptExportType Base => null;
+		public override ScriptExportType Base => null;
 
 		protected sealed override bool IsStruct => throw new NotSupportedException();
 		protected sealed override bool IsSerializable => false;

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportField.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportField.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using uTinyRipper.Assembly;
 
 namespace uTinyRipper.Exporters.Scripts
@@ -25,12 +26,12 @@ namespace uTinyRipper.Exporters.Scripts
 			{
 				writer.Write("new ");
 			}
+			string name = Type.GetTypeQualifiedName(DeclaringType);
 
-			string name = Type.GetTypeNestedName(DeclaringType);
 			name = SerializableType.IsEngineObject(Type.Namespace, name) ? $"{Type.Namespace}.{name}" : name;
+
 			writer.WriteLine("{0} {1};", name, Name);
 		}
-
 		public void ExportEnum(TextWriter writer, int intent)
 		{
 			if (Type.IsEnum)

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportGeneric.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportGeneric.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace uTinyRipper.Exporters.Scripts
 {
@@ -22,6 +23,53 @@ namespace uTinyRipper.Exporters.Scripts
 			}
 			Template.GetUsedNamespaces(namespaces);
 		}
+		private bool IsConcreteArgument(ScriptExportType argument)
+		{
+			return m_manager.TypeNames.Contains($"{argument.Namespace}.{argument.CleanNestedName}");
+		}
+		public override string GetTypeQualifiedName(ScriptExportType relativeType)
+		{
+			/*
+			 * TODO: Generic Arguments won't use the nested typename in the following case
+			 *	public class Example : Base<Nested>
+			 *	{
+			 *		class Nested
+			 *		{
+			 *
+			 *		}
+			 *	}
+			 *
+			 *	Should be Example : Base<Example.Nested>
+			 *	Affected Games: BattleTech
+			 */
+			if (Arguments.Count == 0)
+			{
+				return base.GetTypeQualifiedName(relativeType);
+			}
+			string templateName = Template.GetTypeQualifiedName(relativeType);
+			int index = templateName.IndexOf('<');
+			//Note that Template.TypeName contains ` while NestedName contains <
+			if (index == -1) index = templateName.IndexOf('`');
+			if (index == -1)
+			{
+				//Generic arguments are part of declaring class name
+				return templateName;
+			}
+			StringBuilder sb = new StringBuilder(templateName, 0, index, 50 + index);
+			sb.Append("<");
+			for (int i = 0; i < Arguments.Count; i++)
+			{
+				ScriptExportType argument = Arguments[i];
+				string argumentName = IsConcreteArgument(argument) ? argument.GetTypeQualifiedName(relativeType) : argument.TypeName;
+				sb.Append(argumentName);
+				if (i < Arguments.Count - 1)
+				{
+					sb.Append(", ");
+				}
+			}
+			sb.Append(">");
+			return sb.ToString();
+		}
 
 		public sealed override string CleanNestedName => Template.CleanNestedName;
 		public sealed override bool IsEnum => Template.IsEnum;
@@ -31,6 +79,8 @@ namespace uTinyRipper.Exporters.Scripts
 		public abstract IReadOnlyList<ScriptExportType> Arguments { get; }
 
 		public sealed override IReadOnlyList<ScriptExportField> Fields { get; } = new ScriptExportField[0];
+		public sealed override IReadOnlyList<ScriptExportProperty> Properties { get; } = new ScriptExportProperty[0];
+		public sealed override IReadOnlyList<ScriptExportMethod> Methods { get; } = new ScriptExportMethod[0];
 
 		protected sealed override string Keyword => throw new NotSupportedException();
 

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportMethod.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportMethod.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace uTinyRipper.Exporters.Scripts
+{
+	public abstract class ScriptExportMethod
+	{
+
+		public abstract void Init(IScriptExportManager manager);
+
+		public void Export(TextWriter writer, int intent)
+		{
+			writer.WriteIndent(intent);
+			writer.Write("{0} ", Keyword);
+			if (IsOverride) writer.Write("{0} ", "override");
+
+			string returnName = ReturnType.GetTypeQualifiedName(DeclaringType);
+			writer.Write("{0} {1}(", returnName, Name);
+			for(int i = 0; i < Parameters.Count; i++)
+			{
+				ScriptExportParameter parameter = Parameters[i];
+				parameter.Export(writer, intent);
+				if (i < Parameters.Count - 1) writer.Write(", ");
+			}
+			writer.Write("){");
+			if(ReturnType.TypeName == "void")
+			{
+				writer.WriteLine(" }");
+			} else
+			{
+				writer.WriteLine();
+				writer.WriteIndent(intent + 1);
+				writer.WriteLine("return typeof({0}).IsValueType ? ({0})System.Activator.CreateInstance(typeof({0})) : ({0})(object)null;", returnName);
+				writer.WriteIndent(intent);
+				writer.WriteLine("}");
+			}
+		}
+
+		public void GetUsedNamespaces(ICollection<string> namespaces)
+		{
+			ReturnType.GetTypeNamespaces(namespaces);
+			foreach(ScriptExportParameter parameter in Parameters)
+			{
+				parameter.GetUsedNamespaces(namespaces);
+			}
+		}
+
+		public override string ToString()
+		{
+			if (Name == null)
+			{
+				return base.ToString();
+			}
+			else
+			{
+				return Name;
+			}
+		}
+
+		protected abstract bool IsOverride { get; }
+		public abstract IReadOnlyList<ScriptExportParameter> Parameters { get; }
+		public abstract ScriptExportType ReturnType { get; }
+		public abstract ScriptExportType DeclaringType { get; }
+
+		public abstract string Name { get; }
+
+		protected abstract string Keyword { get; }
+
+		protected const string PublicKeyWord = "public";
+		protected const string InternalKeyWord = "internal";
+		protected const string ProtectedKeyWord = "protected";
+		protected const string PrivateKeyWord = "private";
+	}
+}

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportProperty.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/Elements/ScriptExportProperty.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace uTinyRipper.Exporters.Scripts
+{
+	public abstract class ScriptExportProperty
+	{
+		public abstract void Init(IScriptExportManager manager);
+
+		public void Export(TextWriter writer, int intent)
+		{
+			writer.WriteIndent(intent);
+			if (IsOverride) writer.Write("{0} ", "override");
+			bool sharedKeyword = false;
+			if (HasGetter && !HasSetter) sharedKeyword = true;
+			else if(!HasGetter && HasSetter) sharedKeyword = true;
+			else if(GetKeyword == SetKeyword) sharedKeyword = true;
+			if (sharedKeyword) writer.Write("{0} ", HasGetter ? GetKeyword : SetKeyword);
+			writer.WriteLine("{0} {1} {{", PropertyType.GetTypeQualifiedName(DeclaringType), Name);
+			if (HasGetter)
+			{
+				writer.WriteIndent(intent + 1);
+				if(!sharedKeyword) writer.WriteLine("{0} ", GetKeyword);
+				writer.WriteLine("get {{ return typeof({0}).IsValueType ? ({0})System.Activator.CreateInstance(typeof({0})) : ({0})(object)null; }}", PropertyType.NestedName);
+			}
+			if (HasSetter)
+			{
+				writer.WriteIndent(intent + 1);
+				if (!sharedKeyword) writer.WriteLine("{0} ", SetKeyword);
+				writer.WriteLine("set {  }");
+			}
+			writer.WriteIndent(intent);
+			writer.WriteLine("}");
+		}
+
+		public void GetUsedNamespaces(ICollection<string> namespaces)
+		{
+			PropertyType.GetTypeNamespaces(namespaces);
+		}
+
+		public override string ToString()
+		{
+			if (Name == null)
+			{
+				return base.ToString();
+			}
+			else
+			{
+				return Name;
+			}
+		}
+
+		protected abstract bool IsOverride { get; }
+		protected abstract bool HasGetter { get; }
+		protected abstract bool HasSetter { get; }
+		public abstract ScriptExportType PropertyType { get; }
+		public abstract ScriptExportType DeclaringType { get; }
+
+		public abstract string Name { get; }
+
+		protected abstract string GetKeyword { get; }
+		protected abstract string SetKeyword { get; }
+
+		protected const string PublicKeyWord = "public";
+		protected const string InternalKeyWord = "internal";
+		protected const string ProtectedKeyWord = "protected";
+		protected const string PrivateKeyWord = "private";
+	}
+}

--- a/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/ScriptExportManager.cs
+++ b/uTinyRipperCore/Parser/FileCollection/Exporter/Exporters/Script/ScriptExportManager.cs
@@ -46,8 +46,34 @@ namespace uTinyRipper.Exporters.Scripts
 			return GetExportSubPath(type.Module, type.Namespace, typeName);
 		}
 
+		private void BuildLookup()
+		{
+			void AddTypeNames(ScriptExportType exportType)
+			{
+				m_typeNames.Add($"{exportType.Namespace}.{exportType.CleanNestedName}");
+				foreach (var nested in exportType.NestedEnums)
+				{
+					AddTypeNames(nested);
+				}
+				foreach(var nested in exportType.NestedTypes)
+				{
+					AddTypeNames(nested);
+				}
+			}
+			if (m_typeNames.Count == 0)
+			{
+				m_typeNames.Add("System.Object");
+				foreach (var exportType in Types)
+				{
+					exportType.GetUsedNamespaces(m_namespaces);
+					AddTypeNames(exportType);
+				}
+			}
+		}
+
 		public string Export(ScriptExportType exportType)
 		{
+			BuildLookup();
 			if (exportType.DeclaringType != null)
 			{
 				throw new NotSupportedException("You can export only topmost types");
@@ -219,6 +245,20 @@ namespace uTinyRipper.Exporters.Scripts
 			return exportField;
 		}
 
+		public ScriptExportMethod RetrieveMethod(MethodDefinition method)
+		{
+			ScriptExportMethod exportMethod = new ScriptExportMonoMethod(method);
+			exportMethod.Init(this);
+			return exportMethod;
+		}
+
+		public ScriptExportProperty RetrieveProperty(PropertyDefinition property)
+		{
+			ScriptExportProperty exportProperty = new ScriptExportMonoProperty(property);
+			exportProperty.Init(this);
+			return exportProperty;
+		}
+
 		public ScriptExportParameter RetrieveParameter(ParameterDefinition parameter)
 		{
 			ScriptExportParameter exportParameter = new ScriptExportMonoParameter(parameter);
@@ -373,10 +413,11 @@ namespace uTinyRipper.Exporters.Scripts
 					}
 			}
 		}
-
 		public IEnumerable<ScriptExportType> Types => m_types.Values;
 		public IEnumerable<ScriptExportEnum> Enums => m_enums.Values;
 		public IEnumerable<ScriptExportDelegate> Delegates => m_delegates.Values;
+		public ICollection<string> TypeNames => m_typeNames;
+		public ICollection<string> Namespaces => m_namespaces;
 
 		private const string MSCoreLibName = "mscorlib";
 		private const string NetStandardName = "netstandard";
@@ -389,6 +430,8 @@ namespace uTinyRipper.Exporters.Scripts
 		private const string UnityScriptLangName = "UnityScript.Lang";
 		private const string MonoName = "Mono";
 
+		private readonly HashSet<string> m_namespaces = new HashSet<string>();
+		private readonly HashSet<string> m_typeNames = new HashSet<string>();
 		private readonly Dictionary<string, ScriptExportType> m_types = new Dictionary<string, ScriptExportType>();
 		private readonly Dictionary<string, ScriptExportArray> m_arrays = new Dictionary<string, ScriptExportArray>();
 		private readonly Dictionary<string, ScriptExportGeneric> m_generic = new Dictionary<string, ScriptExportGeneric>();

--- a/uTinyRipperCore/uTinyRipperCore.csproj
+++ b/uTinyRipperCore/uTinyRipperCore.csproj
@@ -195,6 +195,10 @@
     <Compile Include="Parser\FileCollection\Exporter\Exporters\Font\FontExportCollection.cs" />
     <Compile Include="Parser\FileCollection\Exporter\Exporters\MovieTexture\MovieTextureAssetExporter.cs" />
     <Compile Include="Parser\FileCollection\Exporter\Exporters\MovieTexture\MovieTextureExportCollection.cs" />
+    <Compile Include="Parser\FileCollection\Exporter\Exporters\Script\Elements\Mono\ScriptExportMonoMethod.cs" />
+    <Compile Include="Parser\FileCollection\Exporter\Exporters\Script\Elements\Mono\ScriptExportMonoProperty.cs" />
+    <Compile Include="Parser\FileCollection\Exporter\Exporters\Script\Elements\ScriptExportMethod.cs" />
+    <Compile Include="Parser\FileCollection\Exporter\Exporters\Script\Elements\ScriptExportProperty.cs" />
     <Compile Include="Parser\FileCollection\Exporter\Exporters\TextAsset\TextAssetExportCollection.cs" />
     <Compile Include="Parser\FileCollection\Exporter\Exporters\TextAsset\TextAssetExporter.cs" />
     <Compile Include="Parser\FileCollection\Exporter\ExportOptions.cs" />


### PR DESCRIPTION
Export methods and properties that override system and unity abstract…  …
Export qualified typenames when typename is ambiguous
Fixed delegates not exporting

Note that there are still a number of issues remaining:
* Generic Arguments won't use the nested typename in the following case
```csharp
public class Example : Base<Nested>
{
	class Nested
	{
	}
}
```
Should be `Example : Base<Example.Nested>`
Affected Games: BattleTech
* Typenames that conflict with a unity type that isn't referenced directly in the project aren't disambiguated
* Does not find override methods of concrete type when abstract method is generic.
* Abstract classes may have the override methods and properties located in children which may not be exported.
* Constructors should be exported when the unity/system type parent does not have a default constructor

