### PR TITLE
Improved shader restorer

### DIFF
--- a/uTinyRipperCore/Parser/Classes/Shader/Parameters/MatrixParameter.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/Parameters/MatrixParameter.cs
@@ -26,7 +26,7 @@
 			ArraySize = reader.ReadInt32();
 			Type = (ShaderParamType)reader.ReadByte();
 			RowCount = reader.ReadByte();
-			ColumnCount = 0;
+			ColumnCount = 4;
 			reader.AlignStream();
 		}
 

--- a/uTinyRipperCore/Parser/Classes/Shader/ShaderSubProgram.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/ShaderSubProgram.cs
@@ -231,8 +231,13 @@ namespace uTinyRipper.Classes.Shaders
 					{
 						uint textureExtraValue = reader.ReadUInt32();
 						bool isMultiSampled = (textureExtraValue & 1) == 1;
-						byte dimension = (byte)(textureExtraValue >> 1);
-						texture = new TextureParameter(name, index, dimension, extraValue, isMultiSampled);
+						byte dimension = unchecked((byte)extraValue);
+						int samplerIndex = extraValue >> 8;
+						if (samplerIndex == 0xFFFFFF)
+						{
+							samplerIndex = -1;
+						}
+						texture = new TextureParameter(name, index, dimension, samplerIndex, isMultiSampled);
 					}
 					else
 					{

--- a/uTinyRipperCore/Parser/Classes/Shader/ShaderSubProgram.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/ShaderSubProgram.cs
@@ -39,7 +39,13 @@ namespace uTinyRipper.Classes.Shaders
 		{
 			return version.IsGreaterEqual(2017, 3);
 		}
-
+		/// <summary>
+		/// 2018.2 and greater
+		/// </summary>
+		private static bool HasNewTextureParams(Version version)
+		{
+			return version.IsGreaterEqual(2018, 2);
+		}
 		private static int GetMagicNumber(Version version)
 		{
 			if (version.IsEqual(5, 3))
@@ -227,10 +233,18 @@ namespace uTinyRipper.Classes.Shaders
 				if (type == 0)
 				{
 					TextureParameter texture;
-					if (HasMultiSampled(reader.Version))
+					if (HasNewTextureParams(reader.Version))
 					{
 						uint textureExtraValue = reader.ReadUInt32();
 						bool isMultiSampled = (textureExtraValue & 1) == 1;
+						byte dimension = (byte)(textureExtraValue >> 1);
+						int samplerIndex = extraValue;
+						texture = new TextureParameter(name, index, dimension, samplerIndex, isMultiSampled);
+					}
+					else if (HasMultiSampled(reader.Version))
+					{
+						uint textureExtraValue = reader.ReadUInt32();
+						bool isMultiSampled = textureExtraValue == 1;
 						byte dimension = unchecked((byte)extraValue);
 						int samplerIndex = extraValue >> 8;
 						if (samplerIndex == 0xFFFFFF)

--- a/uTinyRipperGUI/ThirdParty/DXShaderRestorer/ResourceBindingChunk.cs
+++ b/uTinyRipperGUI/ThirdParty/DXShaderRestorer/ResourceBindingChunk.cs
@@ -23,6 +23,12 @@ namespace DXShaderRestorer
 				nameLookup[textureParam.Name] = nameOffset;
 				nameOffset += (uint)textureParam.Name.Length + 1;
 			}
+			foreach (TextureParameter textureParam in shaderSubprogram.TextureParameters)
+			{
+				string samplerName = textureParam.Name + "Sampler";
+				nameLookup[samplerName] = nameOffset;
+				nameOffset += (uint)samplerName.Length + 1;
+			}
 			foreach (BufferBinding constantBuffer in shaderSubprogram.ConstantBufferBindings)
 			{
 				nameLookup[constantBuffer.Name] = nameOffset;
@@ -52,7 +58,7 @@ namespace DXShaderRestorer
 				writer.Write((uint)ShaderResourceViewDimension.Buffer);
 				//Number of samples
 				writer.Write((uint)56); //TODO: Check this
-										//Bind point
+				//Bind point
 				writer.Write((uint)bufferParam.Index);
 				bindPoint += 1;
 				//Bind count
@@ -67,7 +73,7 @@ namespace DXShaderRestorer
 			{
 				//Resource bindings
 				//nameOffset
-				writer.Write(m_nameLookup[textureParam.Name]);
+				writer.Write(m_nameLookup[textureParam.Name + "Sampler"]);
 				//shader input type
 				writer.Write((uint)ShaderInputType.Sampler);
 				//Resource return type
@@ -136,6 +142,10 @@ namespace DXShaderRestorer
 			foreach (TextureParameter textureParam in m_shaderSubprogram.TextureParameters)
 			{
 				writer.WriteStringZeroTerm(textureParam.Name);
+			}
+			foreach (TextureParameter textureParam in m_shaderSubprogram.TextureParameters)
+			{
+				writer.WriteStringZeroTerm(textureParam.Name + "Sampler");
 			}
 			foreach (BufferBinding constantBuffer in m_shaderSubprogram.ConstantBufferBindings)
 			{

--- a/uTinyRipperGUI/ThirdParty/DXShaderRestorer/Variable.cs
+++ b/uTinyRipperGUI/ThirdParty/DXShaderRestorer/Variable.cs
@@ -16,6 +16,7 @@ namespace DXShaderRestorer
 			NameIndex = param.NameIndex;
 			Index = param.Index;
 			ArraySize = param.ArraySize;
+			Length = (uint)(param.RowCount * param.ColumnCount * 4);
 		}
 
 		public Variable(VectorParameter param, ShaderGpuProgramType programType)
@@ -25,6 +26,7 @@ namespace DXShaderRestorer
 			NameIndex = param.NameIndex;
 			Index = param.Index;
 			ArraySize = param.ArraySize;
+			Length = (uint)(param.Dim * 4);
 		}
 
 		public Variable(StructParameter param, ShaderGpuProgramType programType)
@@ -47,6 +49,7 @@ namespace DXShaderRestorer
 			variable.Index = index;
 			variable.ArraySize = param.ArraySize;
 			variable.Type = ShaderParamType.Int;
+			variable.Length = (uint)sizeToAdd;
 			return variable;
 		}
 


### PR DESCRIPTION
- Added proper resource bindings for samplers
- Prevent rdef  chunk restoration when shader already contains a rdef chunk.
- Add length values to constant buffer variables.
- Set matrix column count to 4 for SerializedSubProgram Matrix Parameters.
- Fixed shader texture param reading for versions 2017.3 to 2018.1.