### PR TITLE
Improved shader restorer 

### DIFF
--- a/uTinyRipperGUI/ThirdParty/DXShaderRestorer/DXShaderProgramRestorer.cs
+++ b/uTinyRipperGUI/ThirdParty/DXShaderRestorer/DXShaderProgramRestorer.cs
@@ -53,11 +53,11 @@ namespace DXShaderRestorer
 					// Check if shader already has resource chunk
 					foreach (uint chunkOffset in chunkOffsets)
 					{
-						reader.BaseStream.Position = chunkOffset;
+						reader.BaseStream.Position = chunkOffset + baseOffset;
 						uint fourCc = reader.ReadUInt32();
 						if (fourCc == RDEFFourCC)
 						{
-							reader.BaseStream.Position = 0;
+							reader.BaseStream.Position = baseOffset;
 							byte[] original = reader.ReadBytes((int)reader.BaseStream.Length);
 							return original;
 						}

--- a/uTinyRipperGUI/ThirdParty/DXShaderRestorer/DXShaderProgramRestorer.cs
+++ b/uTinyRipperGUI/ThirdParty/DXShaderRestorer/DXShaderProgramRestorer.cs
@@ -38,6 +38,7 @@ namespace DXShaderRestorer
 			{
 				using (BinaryWriter writer = new BinaryWriter(dest))
 				{
+					uint baseOffset = (uint)reader.BaseStream.Position;
 					byte[] magicBytes = reader.ReadBytes(4);
 					byte[] checksum = reader.ReadBytes(16);
 					uint unknown0 = reader.ReadUInt32();
@@ -69,7 +70,7 @@ namespace DXShaderRestorer
 					{
 						chunkOffsets[i] += (uint)resourceChunkData.Length + 4;
 					}
-					chunkOffsets.Insert(0, bodyOffset + 4);
+					chunkOffsets.Insert(0, bodyOffset - baseOffset + 4);
 					chunkCount += 1;
 					totalSize += (uint)resourceChunkData.Length;
 

--- a/uTinyRipperGUI/ThirdParty/DXShaderRestorer/ShaderGpuProgramTypeExtensions.cs
+++ b/uTinyRipperGUI/ThirdParty/DXShaderRestorer/ShaderGpuProgramTypeExtensions.cs
@@ -9,10 +9,12 @@ namespace DXShaderRestorer
 		{
 			switch (_this)
 			{
+				case ShaderGpuProgramType.DX10Level9Pixel:
 				case ShaderGpuProgramType.DX11PixelSM40:
 				case ShaderGpuProgramType.DX11PixelSM50:
 					return DXProgramType.PixelShader;
 
+				case ShaderGpuProgramType.DX10Level9Vertex:
 				case ShaderGpuProgramType.DX11VertexSM40:
 				case ShaderGpuProgramType.DX11VertexSM50:
 					return DXProgramType.VertexShader;
@@ -36,6 +38,8 @@ namespace DXShaderRestorer
 		{
 			switch (_this)
 			{
+				case ShaderGpuProgramType.DX10Level9Vertex:
+				case ShaderGpuProgramType.DX10Level9Pixel:
 				case ShaderGpuProgramType.DX11PixelSM40:
 				case ShaderGpuProgramType.DX11VertexSM40:
 				case ShaderGpuProgramType.DX11GeometrySM40:

--- a/uTinyRipperGUI/ThirdParty/DXShaderRestorer/Variable.cs
+++ b/uTinyRipperGUI/ThirdParty/DXShaderRestorer/Variable.cs
@@ -41,8 +41,18 @@ namespace DXShaderRestorer
 		public static Variable CreateDummyVariable(string name, int index, int sizeToAdd, ShaderGpuProgramType programType)
 		{
 			if (sizeToAdd % 4 != 0 || sizeToAdd <= 0) throw new Exception($"Invalid dummy variable size {sizeToAdd}");
+			
+			//Constant Buffer indices have a stride of 16 bytes
+			var alignIndex = index % 16;
+			if (alignIndex != 0)
+			{
+				index += 16 - alignIndex;
+				sizeToAdd -= 16 - alignIndex;
+			}
+			sizeToAdd -= sizeToAdd % 16;
+
 			Variable variable = new Variable();
-			var param = new VectorParameter(name, ShaderParamType.Int, index, sizeToAdd / 4, 0);
+			var param = new VectorParameter(name, ShaderParamType.Float, index, sizeToAdd / 16, 4);
 			variable.ShaderType = new ShaderType(param, programType);
 			variable.Name = name ?? throw new Exception("Variable name cannot be null");
 			variable.NameIndex = -1;

--- a/uTinyRipperGUI/ThirdParty/DXShaderRestorer/VariableChunk.cs
+++ b/uTinyRipperGUI/ThirdParty/DXShaderRestorer/VariableChunk.cs
@@ -120,22 +120,24 @@ namespace DXShaderRestorer
 				for (int i = 0; i < variables.Count; i++)
 				{
 					Variable variable = variables[i];
-					if (variable.Index > currentSize)
+					if (variable.Index - currentSize >= 16)
 					{
 						long sizeToAdd = variable.Index - currentSize;
 						int id1 = m_constantBufferIndex;
 						int id2 = allVariables.Count;
-						allVariables.Add(Variable.CreateDummyVariable($"unused_{id1}_{id2}", (int)currentSize, (int)sizeToAdd, m_programType));
+						allVariables.Add(Variable.CreateDummyVariable($"unused_{id1}_{id2}",
+								(int)currentSize, (int)sizeToAdd, m_programType));
 					}
 					allVariables.Add(variable);
-					currentSize = (uint)variable.Index + variable.ShaderType.Size();
+					currentSize = (uint)variable.Index + variable.Length;
 				}
-				if (currentSize < constantBuffer.Size)
+				if (constantBuffer.Size - currentSize >= 16)
 				{
 					long sizeToAdd = constantBuffer.Size - currentSize;
 					int id1 = m_constantBufferIndex;
 					int id2 = allVariables.Count;
-					allVariables.Add(Variable.CreateDummyVariable($"unused_{id1}_{id2}", (int)currentSize, (int)sizeToAdd, m_programType));
+					allVariables.Add(Variable.CreateDummyVariable($"unused_{id1}_{id2}", 
+						(int)currentSize, (int)sizeToAdd, m_programType));
 				}
 				variables = allVariables;
 			}


### PR DESCRIPTION
https://github.com/mafaca/UtinyRipper/issues/434
Fixed Shader Restorer when reading from stream with offset would assign chunks the wrong offset
Fixed gap Shader Restorer constant buffer unused variables
Changed Shader Restorer constant buffer unused variables to use float4 arrays instead of int1 array