### PR TITLE
Only convert to long paths when on Windows

### DIFF
--- a/uTinyRipperCore/Utils/DirectoryUtils.cs
+++ b/uTinyRipperCore/Utils/DirectoryUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace uTinyRipper
 {
@@ -59,7 +60,8 @@ namespace uTinyRipper
 
 		public static string ToLongPath(string path, bool force)
 		{
-			if (path.StartsWith(LongPathPrefix, StringComparison.Ordinal))
+			if (path.StartsWith(LongPathPrefix, StringComparison.Ordinal) ||
+				!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			{
 				return path;
 			}


### PR DESCRIPTION
The long path feature (\\?\) is a Windows-only feature, and will break on non-Windows systems.
This PR skips long path conversion if it is not running on Windows.