### PR TITLE
Performance improvements

### DIFF
--- a/uTinyRipperConsole/uTinyRipperConsoleNETCore.csproj
+++ b/uTinyRipperConsole/uTinyRipperConsoleNETCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
 	<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	<AssemblyName>uTinyRipperCmd</AssemblyName>
 	<RootNamespace>uTinyRipperConsole</RootNamespace>

--- a/uTinyRipperCore/Converters/Project/Exporters/BinaryAssetExporter.cs
+++ b/uTinyRipperCore/Converters/Project/Exporters/BinaryAssetExporter.cs
@@ -18,9 +18,10 @@ namespace uTinyRipper.Converters
 
 		public bool Export(IExportContainer container, Object asset, string path)
 		{
-			using (Stream fileStream = FileUtils.CreateVirtualFile(path))
+			using (var fileStream = FileUtils.CreateVirtualFile(path))
+			using (var stream = new BufferedStream(fileStream))
 			{
-				asset.ExportBinary(container, fileStream);
+				asset.ExportBinary(container, stream);
 			}
 			return true;
 		}

--- a/uTinyRipperCore/Parser/Classes/Texture2D/Texture2D.cs
+++ b/uTinyRipperCore/Parser/Classes/Texture2D/Texture2D.cs
@@ -121,7 +121,7 @@ namespace uTinyRipper.Classes
 			return true;
 		}
 
-		public IReadOnlyList<byte> GetImageData()
+		public byte[] GetImageData()
 		{
 			byte[] data = m_imageData;
 			if (HasStreamData(File.Version) && StreamData.IsSet)
@@ -255,8 +255,8 @@ namespace uTinyRipper.Classes
 			node.Add(TextureSettingsName, TextureSettings.ExportYAML(container));
 			node.Add(LightmapFormatName, (int)LightmapFormat);
 			node.Add(ColorSpaceName, (int)ColorSpace);
-			IReadOnlyList<byte> imageData = GetExportImageData();
-			node.Add(ImageDataName, imageData.Count);
+			var imageData = GetExportImageData();
+			node.Add(ImageDataName, imageData.Length);
 			node.Add(container.Layout.TypelessdataName, imageData.ExportYAML());
 			StreamingInfo streamData = new StreamingInfo(true);
 			node.Add(StreamDataName, streamData.ExportYAML(container));
@@ -271,7 +271,7 @@ namespace uTinyRipper.Classes
 			return true;
 #endif
 		}
-		private IReadOnlyList<byte> GetExportImageData()
+		private byte[] GetExportImageData()
 		{
 			if (CheckAssetIntegrity())
 			{

--- a/uTinyRipperCore/Structure/ProjectCollection/Collections/ExportCollection.cs
+++ b/uTinyRipperCore/Structure/ProjectCollection/Collections/ExportCollection.cs
@@ -23,18 +23,17 @@ namespace uTinyRipper.Project
 		protected static void ExportMeta(IExportContainer container, Meta meta, string filePath)
 		{
 			string metaPath = $"{filePath}{MetaExtension}";
-			using (Stream fileStream = FileUtils.CreateVirtualFile(metaPath))
+			using (var fileStream = FileUtils.CreateVirtualFile(metaPath))
+			using (var stream = new BufferedStream(fileStream))
+			using (var streamWriter = new InvariantStreamWriter(stream, new UTF8Encoding(false)))
 			{
-				using (StreamWriter streamWriter = new InvariantStreamWriter(fileStream, new UTF8Encoding(false)))
-				{
-					YAMLWriter writer = new YAMLWriter();
-					writer.IsWriteDefaultTag = false;
-					writer.IsWriteVersion = false;
-					writer.IsFormatKeys = true;
-					YAMLDocument doc = meta.ExportYAMLDocument(container);
-					writer.AddDocument(doc);
-					writer.Write(streamWriter);
-				}
+				YAMLWriter writer = new YAMLWriter();
+				writer.IsWriteDefaultTag = false;
+				writer.IsWriteVersion = false;
+				writer.IsFormatKeys = true;
+				YAMLDocument doc = meta.ExportYAMLDocument(container);
+				writer.AddDocument(doc);
+				writer.Write(streamWriter);
 			}
 		}
 

--- a/uTinyRipperCore/ThirdParty/YAML/Utils/Extensions/IListYAMLExtensions.cs
+++ b/uTinyRipperCore/ThirdParty/YAML/Utils/Extensions/IListYAMLExtensions.cs
@@ -36,6 +36,15 @@ namespace uTinyRipper.YAML
 			return new YAMLScalarNode(sb.ToString(), true);
 		}
 
+		public static YAMLNode ExportYAML(this byte[] _this)
+		{
+			StringBuilder sb = new StringBuilder(_this.Length * 2);
+			for (var i = 0; i < _this.Length; i++) {
+				sb.AppendHex(_this[i]);
+			}
+			return new YAMLScalarNode(sb.ToString(), true);
+		}
+
 		public static YAMLNode ExportYAML(this IReadOnlyList<ushort> _this, bool isRaw)
 		{
 			if (isRaw)

--- a/uTinyRipperCore/Utils/DirectoryUtils.cs
+++ b/uTinyRipperCore/Utils/DirectoryUtils.cs
@@ -59,6 +59,11 @@ namespace uTinyRipper
 
 		public static string ToLongPath(string path, bool force)
 		{
+#if NET_CORE
+			// .NET Core Solution: "It just works because the framework adds the long path syntax for you."
+			// https://stackoverflow.com/a/5188559
+			return path;
+#endif
 			if (path.StartsWith(LongPathPrefix, StringComparison.Ordinal))
 			{
 				return path;

--- a/uTinyRipperCore/Utils/Extensions/StringBuilderExtensions.cs
+++ b/uTinyRipperCore/Utils/Extensions/StringBuilderExtensions.cs
@@ -4,9 +4,17 @@ namespace uTinyRipper
 {
 	public static class StringBuilderExtensions
 	{
+		private static string[] ByteHexRepresentations = new string[256];
+
+		static StringBuilderExtensions() {
+			for (var i = 0; i < 256; i ++) {
+				ByteHexRepresentations[i] = ((byte)i).ToString("x2");
+			}
+		}
+
 		public static StringBuilder AppendHex(this StringBuilder _this, byte value)
 		{
-			_this.Append(value.ToString("x2"));
+			_this.Append(ByteHexRepresentations[value]);
 			return _this;
 		}
 

--- a/uTinyRipperCore/Utils/Extensions/StringBuilderExtensions.cs
+++ b/uTinyRipperCore/Utils/Extensions/StringBuilderExtensions.cs
@@ -6,8 +6,7 @@ namespace uTinyRipper
 	{
 		public static StringBuilder AppendHex(this StringBuilder _this, byte value)
 		{
-			_this.Append(HexAlphabet[value >> 4]);
-			_this.Append(HexAlphabet[value & 0xF]);
+			_this.Append(value.ToString("x2"));
 			return _this;
 		}
 

--- a/uTinyRipperCore/Utils/FileUtils.cs
+++ b/uTinyRipperCore/Utils/FileUtils.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace uTinyRipper
 {
@@ -155,30 +152,10 @@ namespace uTinyRipper
 
 			ext = ext ?? Path.GetExtension(validFileName);
 			name = name ?? Path.GetFileNameWithoutExtension(validFileName);
-
-			string escapedName = Regex.Escape(name);
-			List<string> files = new List<string>();
-			DirectoryInfo dirInfo = new DirectoryInfo(DirectoryUtils.ToLongPath(dirPath, true));
-			Regex regex = new Regex($@"(?i)^{escapedName}(_[\d]+)?\.[^\.]+$");
-			foreach (FileInfo fileInfo in dirInfo.EnumerateFiles($"{name}_*{ext}"))
-			{
-				if (regex.IsMatch(fileInfo.Name))
-				{
-					files.Add(fileInfo.Name.ToLower());
-				}
-			}
-			if (files.Count == 0)
-			{
-				return $"{name}_0{ext}";
-			}
-
-			string lowName = name.ToLower();
-			for (int i = 1; i < int.MaxValue; i++)
-			{
-				string newName = $"{lowName}_{i}.";
-				if (files.All(t => !t.StartsWith(newName, StringComparison.Ordinal)))
-				{
-					return $"{name}_{i}{ext}";
+			for(int counter = 0; counter < int.MaxValue; counter++) {
+				var proposedName = $"{name}_{counter}{ext}";
+				if (!File.Exists(Path.Combine(dirPath, proposedName))) {
+					return proposedName;
 				}
 			}
 			throw new Exception($"Can't generate unique name for file {fileName} in directory {dirPath}");

--- a/uTinyRipperCore/Utils/FileUtils.cs
+++ b/uTinyRipperCore/Utils/FileUtils.cs
@@ -79,6 +79,11 @@ namespace uTinyRipper
 
 		public static string ToLongPath(string path)
 		{
+#if NET_CORE
+			// .NET Core Solution: "It just works because the framework adds the long path syntax for you."
+			// https://stackoverflow.com/a/5188559
+			return path;
+#endif
 			if (path.StartsWith(DirectoryUtils.LongPathPrefix, StringComparison.Ordinal))
 			{
 				return path;

--- a/uTinyRipperCore/uTinyRipperCore.csproj
+++ b/uTinyRipperCore/uTinyRipperCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.2</LangVersion>
 	<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	<AssemblyName>uTinyRipperCore</AssemblyName>

--- a/uTinyRipperGUI/uTinyRipperGUI.csproj
+++ b/uTinyRipperGUI/uTinyRipperGUI.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>uTinyRipperGUI</RootNamespace>
     <AssemblyName>uTinyRipper</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <BaseIntermediateOutputPath>..\Bins\obj\</BaseIntermediateOutputPath>


### PR DESCRIPTION
I profiled UtinyRipper a little with DotTrace, and found some hot functions that could be optimized.

For a game of 500 asset collections, mostly Texture2D, total run time fell from 00:33 to 00:28, i.e. a 20% improvement. (An experiment to further offload YAML serialization to Task threads seem to drop runtime to 00:22, i.e. +50% from baseline, but that still requires more safety work.)