### PR TITLE
fix exporting shader when snippet less than 5

### DIFF
--- a/uTinyRipperGUI/Exporters/Shader/ShaderVulkanExporter.cs
+++ b/uTinyRipperGUI/Exporters/Shader/ShaderVulkanExporter.cs
@@ -18,10 +18,16 @@ namespace uTinyRipperGUI.Exporters
 				{
 					const int SnippetCount = 5;
 					int unknown = reader.ReadInt32();
+					int minOffset = subProgram.ProgramData.Length;
 					for (int i = 0; i < SnippetCount; i++)
 					{
+						if (((i + 1) * 2 + 1) * 4 > minOffset)
+							break;
+
 						int offset = reader.ReadInt32();
 						int size = reader.ReadInt32();
+						if (offset < minOffset)
+							minOffset = offset;
 
 						if (size > 0)
 						{


### PR DESCRIPTION
Sometimes we have less than `const int SnippetCount = 5;` snippets. So check offset and don't read into data block.