### PR TITLE
Support AssetBundle container paths for export paths

### DIFF
--- a/uTinyRipperCore/Converters/Project/Exporter/ProjectAssetContainer.cs
+++ b/uTinyRipperCore/Converters/Project/Exporter/ProjectAssetContainer.cs
@@ -12,18 +12,6 @@ namespace uTinyRipper.Converters
 {
 	public class ProjectAssetContainer : IExportContainer
 	{
-		private struct AssetBundlePath
-		{
-			public AssetBundlePath(AssetBundle bundle, string path)
-			{
-				Bundle = bundle;
-				Path = path;
-			}
-
-			public AssetBundle Bundle { get; }
-			public string Path { get; }
-		}
-
 		public ProjectAssetContainer(ProjectExporter exporter, VirtualSerializedFile file, IEnumerable<Object> assets,
 			IReadOnlyList<IExportCollection> collections)
 		{
@@ -84,10 +72,10 @@ namespace uTinyRipper.Converters
 						assetPath = ResourceManager.ResourceToExportPath(asset, path);
 						return true;
 					}
-					if (m_assetBundlePaths.TryGetValue(asset, out AssetBundlePath assetBundlePath))
+					if (m_assetBundlePaths.TryGetValue(asset, out string assetBundlePath))
 					{
 						selectedAsset = asset;
-						assetPath = assetBundlePath.Bundle.AssetToExportPath(asset, assetBundlePath.Path);
+						assetPath = AssetBundle.AssetToExportPath(asset, assetBundlePath);
 						return true;
 					}
 				}
@@ -314,7 +302,7 @@ namespace uTinyRipper.Converters
 				Object asset = kvp.Value.Asset.FindAsset(bundle.File);
 				if (asset != null)
 				{
-					m_assetBundlePaths.Add(asset, new AssetBundlePath(bundle, kvp.Key));
+					m_assetBundlePaths.Add(asset, kvp.Key);
 				}
 			}
 		}
@@ -338,7 +326,9 @@ namespace uTinyRipper.Converters
 		// Both ResourceManager and AssetBundle should neither exist in the same ProjectAssetContainer nor share asset Objects,
 		// but just in case they somehow do, keeping m_resources and m_assetBundlePaths separately rather than merging the two.
 		private readonly Dictionary<Object, string> m_resources = new Dictionary<Object, string>();
-		private readonly Dictionary<Object, AssetBundlePath> m_assetBundlePaths = new Dictionary<Object, AssetBundlePath>();
+		// Also assume that there's at most a single AssetBundle in the ProjectAssetContainer, so we don't need to disambiguate
+		// between multiple asset bundle names.
+		private readonly Dictionary<Object, string> m_assetBundlePaths = new Dictionary<Object, string>();
 
 		private readonly BuildSettings m_buildSettings;
 		private readonly TagManager m_tagManager;

--- a/uTinyRipperCore/Converters/Project/Exporter/ProjectAssetContainer.cs
+++ b/uTinyRipperCore/Converters/Project/Exporter/ProjectAssetContainer.cs
@@ -12,6 +12,18 @@ namespace uTinyRipper.Converters
 {
 	public class ProjectAssetContainer : IExportContainer
 	{
+		private struct AssetBundlePath
+		{
+			public AssetBundlePath(AssetBundle bundle, string path)
+			{
+				Bundle = bundle;
+				Path = path;
+			}
+
+			public AssetBundle Bundle { get; }
+			public string Path { get; }
+		}
+
 		public ProjectAssetContainer(ProjectExporter exporter, VirtualSerializedFile file, IEnumerable<Object> assets,
 			IReadOnlyList<IExportCollection> collections)
 		{
@@ -34,6 +46,10 @@ namespace uTinyRipper.Converters
 					case ClassIDType.ResourceManager:
 						AddResources((ResourceManager)asset);
 						break;
+
+					case ClassIDType.AssetBundle:
+						AddAssets((AssetBundle)asset);
+						break;
 				}
 			}
 
@@ -54,18 +70,24 @@ namespace uTinyRipper.Converters
 		}
 
 #warning TODO: get rid of IEnumerable. pass only main asset (issues: prefab, texture with sprites, animatorController)
-		public bool TryGetResourcePathFromAssets(IEnumerable<Object> assets, out Object selectedAsset, out string resourcePath)
+		public bool TryGetAssetPathFromAssets(IEnumerable<Object> assets, out Object selectedAsset, out string assetPath)
 		{
 			selectedAsset = null;
-			resourcePath = string.Empty;
-			if (m_resources.Count > 0)
+			assetPath = string.Empty;
+			if (m_resources.Count > 0 || m_assetBundlePaths.Count > 0)
 			{
 				foreach (Object asset in assets)
 				{
 					if (m_resources.TryGetValue(asset, out string path))
 					{
 						selectedAsset = asset;
-						resourcePath = ResourceManager.ResourceToExportPath(asset, path);
+						assetPath = ResourceManager.ResourceToExportPath(asset, path);
+						return true;
+					}
+					if (m_assetBundlePaths.TryGetValue(asset, out AssetBundlePath assetBundlePath))
+					{
+						selectedAsset = asset;
+						assetPath = assetBundlePath.Bundle.AssetToExportPath(asset, assetBundlePath.Path);
 						return true;
 					}
 				}
@@ -218,7 +240,7 @@ namespace uTinyRipper.Converters
 			{
 				// Unity doesn't verify tagID on export?
 				int tagIndex = tagID - 20000;
-				if (tagIndex < m_tagManager.Tags.Length)
+				if (tagIndex >= 0 && tagIndex < m_tagManager.Tags.Length)
 				{
 					return m_tagManager.Tags[tagIndex];
 				}
@@ -268,19 +290,31 @@ namespace uTinyRipper.Converters
 					continue;
 				}
 
+				string resourcePath = kvp.Key;
 				if (m_resources.ContainsKey(asset))
 				{
 					// for paths like "Resources/inner/resources/extra/file" engine creates 2 resource entries
 					// "inner/resources/extra/file" and "extra/file"
-					string path = m_resources[asset];
-					if (path.Length < kvp.Key.Length)
+					if (m_resources[asset].Length < resourcePath.Length)
 					{
-						m_resources[asset] = kvp.Key;
+						m_resources[asset] = resourcePath;
 					}
 				}
 				else
 				{
-					m_resources.Add(asset, kvp.Key);
+					m_resources.Add(asset, resourcePath);
+				}
+			}
+		}
+
+		private void AddAssets(AssetBundle bundle)
+		{
+			foreach (KeyValuePair<string, Classes.AssetBundles.AssetInfo> kvp in bundle.Container)
+			{
+				Object asset = kvp.Value.Asset.FindAsset(bundle.File);
+				if (asset != null)
+				{
+					m_assetBundlePaths.Add(asset, new AssetBundlePath(bundle, kvp.Key));
 				}
 			}
 		}
@@ -301,7 +335,10 @@ namespace uTinyRipper.Converters
 
 		private readonly ProjectExporter m_exporter;
 		private readonly Dictionary<AssetInfo, IExportCollection> m_assetCollections = new Dictionary<AssetInfo, IExportCollection>();
+		// Both ResourceManager and AssetBundle should neither exist in the same ProjectAssetContainer nor share asset Objects,
+		// but just in case they somehow do, keeping m_resources and m_assetBundlePaths separately rather than merging the two.
 		private readonly Dictionary<Object, string> m_resources = new Dictionary<Object, string>();
+		private readonly Dictionary<Object, AssetBundlePath> m_assetBundlePaths = new Dictionary<Object, AssetBundlePath>();
 
 		private readonly BuildSettings m_buildSettings;
 		private readonly TagManager m_tagManager;

--- a/uTinyRipperCore/Converters/Project/Exporter/ProjectAssetContainer.cs
+++ b/uTinyRipperCore/Converters/Project/Exporter/ProjectAssetContainer.cs
@@ -228,7 +228,7 @@ namespace uTinyRipper.Converters
 			{
 				// Unity doesn't verify tagID on export?
 				int tagIndex = tagID - 20000;
-				if (tagIndex >= 0 && tagIndex < m_tagManager.Tags.Length)
+				if (tagIndex < m_tagManager.Tags.Length)
 				{
 					return m_tagManager.Tags[tagIndex];
 				}

--- a/uTinyRipperCore/Parser/Classes/AssetBundle/AssetBundle.cs
+++ b/uTinyRipperCore/Parser/Classes/AssetBundle/AssetBundle.cs
@@ -71,15 +71,28 @@ namespace uTinyRipper.Classes
 
 		public static string AssetToExportPath(Object asset, string assetPath)
 		{
-			// AssetExportCollection.Export appends its own extension, so strip any extension off the asset path.
-			string extension = Path.GetExtension(assetPath);
-			if (extension != null)
+			string assetName = asset.TryGetName();
+			if (assetName.Length > 0 && assetName != assetPath)
 			{
-				assetPath = assetPath.Substring(0, assetPath.Length - extension.Length);
+				string exportPath = SubstituteExportPath(assetName, assetPath);
+				if (exportPath != null)
+					return exportPath;
+
+				string extension = Path.GetExtension(assetPath);
+				if (extension != null)
+				{
+					exportPath = SubstituteExportPath(assetName, assetPath.Substring(0, assetPath.Length - extension.Length));
+					if (exportPath != null)
+						return exportPath;
+				}
 			}
 
-			string assetName = asset.TryGetName();
-			if (assetName.Length > 0 && assetName != assetPath && assetPath.EndsWith(assetName, StringComparison.OrdinalIgnoreCase))
+			return assetPath;
+		}
+
+		private static string SubstituteExportPath(string assetName, string assetPath)
+		{
+			if (assetPath.EndsWith(assetName, StringComparison.OrdinalIgnoreCase))
 			{
 				if (assetName.Length == assetPath.Length ||
 					assetPath[assetPath.Length - assetName.Length - 1] == DirectorySeparator)
@@ -88,8 +101,7 @@ namespace uTinyRipper.Classes
 					return directoryPath + assetName;
 				}
 			}
-
-			return assetPath;
+			return null;
 		}
 
 		public override void Read(AssetReader reader)

--- a/uTinyRipperCore/Parser/Classes/AssetBundle/AssetBundle.cs
+++ b/uTinyRipperCore/Parser/Classes/AssetBundle/AssetBundle.cs
@@ -69,11 +69,27 @@ namespace uTinyRipper.Classes
 		/// </summary>
 		public static bool HasSceneHashes(Version version) => version.IsGreaterEqual(2017, 3);
 
-		public string AssetToExportPath(Object asset, string assetName)
+		public static string AssetToExportPath(Object asset, string assetPath)
 		{
-			// Folder structure inferred from https://docs.unity3d.com/Manual/AssetBundles-Manager.html
-			var basePath = Path.Combine(AssetBundlesKeyword, AssetBundleName);
-			return ResourceManager.AssetToExportPath(asset, basePath, assetName);
+			// AssetExportCollection.Export appends its own extension, so strip any extension off the asset path.
+			string extension = Path.GetExtension(assetPath);
+			if (extension != null)
+			{
+				assetPath = assetPath.Substring(0, assetPath.Length - extension.Length);
+			}
+
+			string assetName = asset.TryGetName();
+			if (assetName.Length > 0 && assetName != assetPath && assetPath.EndsWith(assetName, StringComparison.OrdinalIgnoreCase))
+			{
+				if (assetName.Length == assetPath.Length ||
+					assetPath[assetPath.Length - assetName.Length - 1] == DirectorySeparator)
+				{
+					string directoryPath = assetPath.Substring(0, assetPath.Length - assetName.Length);
+					return directoryPath + assetName;
+				}
+			}
+
+			return assetPath;
 		}
 
 		public override void Read(AssetReader reader)
@@ -167,7 +183,7 @@ namespace uTinyRipper.Classes
 		public int PathFlags { get; set; }
 		public Dictionary<string, string> SceneHashes { get; set; }
 
-		public const string AssetBundlesKeyword = "AssetBundles";
+		private const char DirectorySeparator = '/';
 
 		public const string ContainerName = "m_Container";
 

--- a/uTinyRipperCore/Parser/Classes/AssetBundle/AssetBundle.cs
+++ b/uTinyRipperCore/Parser/Classes/AssetBundle/AssetBundle.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using uTinyRipper.Classes.AssetBundles;
 using uTinyRipper.YAML;
@@ -67,6 +68,13 @@ namespace uTinyRipper.Classes
 		/// 2017.3 and greater
 		/// </summary>
 		public static bool HasSceneHashes(Version version) => version.IsGreaterEqual(2017, 3);
+
+		public string AssetToExportPath(Object asset, string assetName)
+		{
+			// Folder structure inferred from https://docs.unity3d.com/Manual/AssetBundles-Manager.html
+			var basePath = Path.Combine(AssetBundlesKeyword, AssetBundleName);
+			return ResourceManager.AssetToExportPath(asset, basePath, assetName);
+		}
 
 		public override void Read(AssetReader reader)
 		{
@@ -158,6 +166,8 @@ namespace uTinyRipper.Classes
 		public int ExplicitDataLayout { get; set; }
 		public int PathFlags { get; set; }
 		public Dictionary<string, string> SceneHashes { get; set; }
+
+		public const string AssetBundlesKeyword = "AssetBundles";
 
 		public const string ContainerName = "m_Container";
 

--- a/uTinyRipperCore/Parser/Classes/ResourceManager/ResourceManager.cs
+++ b/uTinyRipperCore/Parser/Classes/ResourceManager/ResourceManager.cs
@@ -22,17 +22,22 @@ namespace uTinyRipper.Classes
 
 		public static string ResourceToExportPath(Object asset, string resourceName)
 		{
+			return AssetToExportPath(asset, ResourceBasePath, resourceName);
+		}
+
+		public static string AssetToExportPath(Object asset, string basePath, string assetPath)
+		{
 			bool replace = false;
 			string validName = asset.TryGetName();
 			if (validName.Length > 0)
 			{
-				if (validName != resourceName && resourceName.EndsWith(validName, StringComparison.OrdinalIgnoreCase))
+				if (validName != assetPath && assetPath.EndsWith(validName, StringComparison.OrdinalIgnoreCase))
 				{
-					if (validName.Length == resourceName.Length)
+					if (validName.Length == assetPath.Length)
 					{
 						replace = true;
 					}
-					else if (resourceName[resourceName.Length - validName.Length - 1] == DirectorySeparator)
+					else if (assetPath[assetPath.Length - validName.Length - 1] == DirectorySeparator)
 					{
 						replace = true;
 					}
@@ -41,12 +46,12 @@ namespace uTinyRipper.Classes
 
 			if (replace)
 			{
-				string directoryPath = resourceName.Substring(0, resourceName.Length - validName.Length);
-				return Path.Combine(AssetsKeyword, ResourceKeyword, directoryPath + validName);
+				string directoryPath = assetPath.Substring(0, assetPath.Length - validName.Length);
+				return Path.Combine(basePath, directoryPath + validName);
 			}
 			else
 			{
-				return Path.Combine(AssetsKeyword, ResourceKeyword, resourceName);
+				return Path.Combine(basePath, assetPath);
 			}
 		}
 
@@ -111,7 +116,9 @@ namespace uTinyRipper.Classes
 		public ResourceManagerDependency[] DependentAssets { get; set; }
 
 		public const string ResourceKeyword = "Resources";
-		public const char DirectorySeparator = '/';
+
+		private static readonly string ResourceBasePath = Path.Combine(AssetsKeyword, ResourceKeyword);
+		private const char DirectorySeparator = '/';
 
 		public const string ContainerName = "m_Container";
 		public const string DependentAssetsName = "m_DependentAssets";

--- a/uTinyRipperCore/Parser/Classes/ResourceManager/ResourceManager.cs
+++ b/uTinyRipperCore/Parser/Classes/ResourceManager/ResourceManager.cs
@@ -22,37 +22,7 @@ namespace uTinyRipper.Classes
 
 		public static string ResourceToExportPath(Object asset, string resourceName)
 		{
-			return AssetToExportPath(asset, ResourceBasePath, resourceName);
-		}
-
-		public static string AssetToExportPath(Object asset, string basePath, string assetPath)
-		{
-			bool replace = false;
-			string validName = asset.TryGetName();
-			if (validName.Length > 0)
-			{
-				if (validName != assetPath && assetPath.EndsWith(validName, StringComparison.OrdinalIgnoreCase))
-				{
-					if (validName.Length == assetPath.Length)
-					{
-						replace = true;
-					}
-					else if (assetPath[assetPath.Length - validName.Length - 1] == DirectorySeparator)
-					{
-						replace = true;
-					}
-				}
-			}
-
-			if (replace)
-			{
-				string directoryPath = assetPath.Substring(0, assetPath.Length - validName.Length);
-				return Path.Combine(basePath, directoryPath + validName);
-			}
-			else
-			{
-				return Path.Combine(basePath, assetPath);
-			}
+			return Path.Combine(ResourceBasePath, AssetBundle.AssetToExportPath(asset, resourceName));
 		}
 
 		public bool TryGetResourcePathFromAsset(Object asset, out string resourcePath)
@@ -118,7 +88,6 @@ namespace uTinyRipper.Classes
 		public const string ResourceKeyword = "Resources";
 
 		private static readonly string ResourceBasePath = Path.Combine(AssetsKeyword, ResourceKeyword);
-		private const char DirectorySeparator = '/';
 
 		public const string ContainerName = "m_Container";
 		public const string DependentAssetsName = "m_DependentAssets";

--- a/uTinyRipperCore/Structure/ProjectCollection/Collections/AssetExportCollection.cs
+++ b/uTinyRipperCore/Structure/ProjectCollection/Collections/AssetExportCollection.cs
@@ -28,9 +28,9 @@ namespace uTinyRipper.Project
 		{
 			string subPath;
 			string fileName;
-			if (container.TryGetResourcePathFromAssets(Assets, out Object asset, out string subResourcePath))
+			if (container.TryGetAssetPathFromAssets(Assets, out Object asset, out string assetPath))
 			{
-				string resourcePath = Path.Combine(dirPath, $"{subResourcePath}.{GetExportExtension(asset)}");
+				string resourcePath = Path.Combine(dirPath, $"{assetPath}.{GetExportExtension(asset)}");
 				subPath = Path.GetDirectoryName(resourcePath);
 				string resFileName = Path.GetFileName(resourcePath);
 #warning TODO: combine assets with the same res path into one big asset


### PR DESCRIPTION
1. Support reading AssetBundle container paths and using them for asset export paths. This addresses #56.

~~2. Avoid `IndexOutOfRangeException` for tag indices > 7 and < 20000.
For an older Unity project, I discovered the following tag indices with a TagManager that had no tags:
"GameRoot(GameObject)" => tag 8
"MapInitParams(GameObject)" => tag 9
"Camera(GameObject)" => tag 10
I have no idea what those tags refer too, nor do I have access to the source.~~

3. (new) Avoid duplicate file extensions in export paths if container paths also contain file extensions.