### PR TITLE
Fix scenes being exported outside the target directory

### DIFF
--- a/uTinyRipperCore/Structure/ProjectCollection/Collections/SceneExportCollection.cs
+++ b/uTinyRipperCore/Structure/ProjectCollection/Collections/SceneExportCollection.cs
@@ -220,10 +220,14 @@ namespace uTinyRipper.Project
 			{
 				int index = FileNameToSceneIndex(Name, File.Version);
 				string scenePath = container.SceneIndexToName(index);
-				int assetsNameIndex = scenePath.IndexOf(AssetsName, StringComparison.Ordinal);
-				if (assetsNameIndex != -1)
+				bool rooted = DirectoryUtils.IsPathRooted(AssetsName, out int prefixLength);
+				if (rooted || assetsNameIndex == 0)
 				{
-					string relativePath = scenePath.Substring(assetsNameIndex + AssetsName.Length);
+					if (rooted && assetsNameIndex != -1)
+					{
+						prefixLength = assetsNameIndex;
+					}
+					string relativePath = scenePath.Substring(prefixLength + AssetsName.Length);
 					string extension = Path.GetExtension(scenePath);
 					return relativePath.Substring(0, relativePath.Length - extension.Length);
 				}

--- a/uTinyRipperCore/Structure/ProjectCollection/Collections/SceneExportCollection.cs
+++ b/uTinyRipperCore/Structure/ProjectCollection/Collections/SceneExportCollection.cs
@@ -220,6 +220,7 @@ namespace uTinyRipper.Project
 			{
 				int index = FileNameToSceneIndex(Name, File.Version);
 				string scenePath = container.SceneIndexToName(index);
+				int assetsNameIndex = scenePath.IndexOf(AssetsName, StringComparison.Ordinal);
 				bool rooted = DirectoryUtils.IsPathRooted(AssetsName, out int prefixLength);
 				if (rooted || assetsNameIndex == 0)
 				{

--- a/uTinyRipperCore/Structure/ProjectCollection/Collections/SceneExportCollection.cs
+++ b/uTinyRipperCore/Structure/ProjectCollection/Collections/SceneExportCollection.cs
@@ -220,9 +220,10 @@ namespace uTinyRipper.Project
 			{
 				int index = FileNameToSceneIndex(Name, File.Version);
 				string scenePath = container.SceneIndexToName(index);
-				if (scenePath.StartsWith(AssetsName, StringComparison.Ordinal))
+				int assetsNameIndex = scenePath.IndexOf(AssetsName, StringComparison.Ordinal);
+				if (assetsNameIndex != -1)
 				{
-					string relativePath = scenePath.Substring(AssetsName.Length);
+					string relativePath = scenePath.Substring(assetsNameIndex + AssetsName.Length);
 					string extension = Path.GetExtension(scenePath);
 					return relativePath.Substring(0, relativePath.Length - extension.Length);
 				}

--- a/uTinyRipperCore/Utils/DirectoryUtils.cs
+++ b/uTinyRipperCore/Utils/DirectoryUtils.cs
@@ -79,6 +79,31 @@ namespace uTinyRipper
 			}
 			return path;
 		}
+		
+		public static bool IsPathRooted(string path, out int prefixLength)
+		{
+			if (path.StartsWith(LongPathPrefix, StringComparison.Ordinal))
+			{
+				// TODO: prefix lengths for things other than drives
+				prefixLength = 7;
+				return true;
+			}
+
+			if (path.StartsWith("/", StringComparison.Ordinal))
+			{
+				prefixLength = 1;
+				return true;
+			}
+
+			if (path.Length > 3 && char.IsLetter(path[0]) && path[1] == ':' && path[2] == '\\')
+			{
+				prefixLength = 3;
+				return true;
+			}
+
+			prefixLength = 0;
+			return false;
+		}
 
 		public const string LongPathPrefix = @"\\?\";
 		public const int MaxDirectoryLength = 248;


### PR DESCRIPTION
Sometimes the scene name can be an absolute path (example: Distance / Unity 5.5.6f1) which will cause them to exported to that path because of the Path.Combine in https://github.com/mafaca/UtinyRipper/blob/master/uTinyRipperCore/Structure/ProjectCollection/Collections/SceneExportCollection.cs#L113.

This check may be too loose and could omit legitimate parts of a scene name.
And exporting to outside paths could be an issue with other asset types and be worth checking for in FileUtils.CreateVirtualFile (or a different more, appropriate place)