### PR TITLE
Refactor indenting in code and shader export

### DIFF
--- a/uTinyRipperCore/Converters/Classes/Shader/Exporters/ShaderMetalExporter.cs
+++ b/uTinyRipperCore/Converters/Classes/Shader/Exporters/ShaderMetalExporter.cs
@@ -29,7 +29,7 @@ namespace uTinyRipper.Converters.Shaders
 
 					using (StreamReader streamReader = new StreamReader(reader.BaseStream))
 					{
-						writer.Write(streamReader.ReadToEnd());
+						writer.WriteIndentedFull(streamReader.ReadToEnd().Trim());
 					}
 				}
 			}

--- a/uTinyRipperCore/Converters/Classes/Shader/Exporters/ShaderMetalExporter.cs
+++ b/uTinyRipperCore/Converters/Classes/Shader/Exporters/ShaderMetalExporter.cs
@@ -27,7 +27,10 @@ namespace uTinyRipper.Converters.Shaders
 						}
 					}
 
-					ExportText(writer, reader);
+					using (StreamReader streamReader = new StreamReader(reader.BaseStream))
+					{
+						writer.Write(streamReader.ReadToEnd());
+					}
 				}
 			}
 		}

--- a/uTinyRipperCore/Converters/Classes/Shader/Exporters/ShaderTextExporter.cs
+++ b/uTinyRipperCore/Converters/Classes/Shader/Exporters/ShaderTextExporter.cs
@@ -10,79 +10,11 @@ namespace uTinyRipper.Converters.Shaders
 			byte[] exportData = subProgram.ProgramData;
 			using (MemoryStream memStream = new MemoryStream(exportData))
 			{
-				using (BinaryReader reader = new BinaryReader(memStream))
+				using (StreamReader reader = new StreamReader(memStream))
 				{
-					ExportText(writer, reader);
+					writer.Write(reader.ReadToEnd());
 				}
 			}
 		}
-
-		protected static void ExportText(TextWriter writer, BinaryReader reader)
-		{
-			while (reader.BaseStream.Position != reader.BaseStream.Length)
-			{
-				char c = reader.ReadChar();
-				if (c == '\n')
-				{
-					if (reader.BaseStream.Position == reader.BaseStream.Length)
-					{
-						break;
-					}
-					writer.Write(c);
-					writer.WriteIndent(ExpectedIndent);
-				}
-				else
-				{
-					writer.Write(c);
-				}
-			}
-		}
-
-		protected static void ExportListing(TextWriter writer, string listing)
-		{
-			writer.Write('\n');
-			writer.WriteIndent(ExpectedIndent);
-
-			for (int i = 0; i < listing.Length;)
-			{
-				char c = listing[i++];
-				bool newLine = false;
-				if (c == '\r')
-				{
-					if (i == listing.Length)
-					{
-						newLine = true;
-					}
-					else
-					{
-						char nc = listing[i];
-						if (nc != '\n')
-						{
-							newLine = true;
-						}
-					}
-				}
-				else if (c == '\n')
-				{
-					newLine = true;
-				}
-
-				if (newLine)
-				{
-					if (i == listing.Length)
-					{
-						break;
-					}
-					writer.Write(c);
-					writer.WriteIndent(ExpectedIndent);
-				}
-				else
-				{
-					writer.Write(c);
-				}
-			}
-		}
-
-		protected const int ExpectedIndent = 5;
 	}
 }

--- a/uTinyRipperCore/Converters/Classes/Shader/Exporters/ShaderTextExporter.cs
+++ b/uTinyRipperCore/Converters/Classes/Shader/Exporters/ShaderTextExporter.cs
@@ -12,7 +12,7 @@ namespace uTinyRipper.Converters.Shaders
 			{
 				using (StreamReader reader = new StreamReader(memStream))
 				{
-					writer.Write(reader.ReadToEnd());
+					writer.WriteIndentedFull(reader.ReadToEnd().Trim());
 				}
 			}
 		}

--- a/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportAttribute.cs
+++ b/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportAttribute.cs
@@ -7,9 +7,8 @@ namespace uTinyRipper.Converters.Script
 	{
 		public abstract void Init(IScriptExportManager manager);
 
-		public void Export(TextWriter writer, int intent)
+		public void Export(CodeWriter writer)
 		{
-			writer.WriteIndent(intent);
 			writer.WriteLine("[{0}]", Name);
 		}
 

--- a/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportDelegate.cs
+++ b/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportDelegate.cs
@@ -6,14 +6,13 @@ namespace uTinyRipper.Converters.Script
 {
 	public abstract class ScriptExportDelegate : ScriptExportType
 	{
-		public sealed override void Export(TextWriter writer, int intent)
+		public sealed override void Export(CodeWriter writer)
 		{
-			writer.WriteIndent(intent);
 			writer.Write("{0} delegate {1} {2}(", Keyword, Return.NestedName, TypeName);
 			for (int i = 0; i < Parameters.Count; i++)
 			{
 				ScriptExportParameter parameter = Parameters[i];
-				parameter.Export(writer, intent);
+				parameter.Export(writer);
 				if (i < Parameters.Count - 1)
 				{
 					writer.Write(',');

--- a/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportEnum.cs
+++ b/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportEnum.cs
@@ -6,9 +6,8 @@ namespace uTinyRipper.Converters.Script
 {
 	public abstract class ScriptExportEnum : ScriptExportType
 	{
-		public sealed override void Export(TextWriter writer, int intent)
+		public sealed override void Export(CodeWriter writer)
 		{
-			writer.WriteIndent(intent);
 			writer.Write("{0} enum {1}", Keyword, TypeName);
 			if (Base != null && Base.TypeName != MonoUtils.IntName)
 			{
@@ -16,16 +15,13 @@ namespace uTinyRipper.Converters.Script
 			}
 			writer.WriteLine();
 
-			writer.WriteIndent(intent++);
-			writer.WriteLine('{');
-
-			foreach (ScriptExportField field in Fields)
+			using (writer.IndentBrackets())
 			{
-				field.ExportEnum(writer, intent);
+				foreach (ScriptExportField field in Fields)
+				{
+					field.ExportEnum(writer);
+				}
 			}
-
-			writer.WriteIndent(--intent);
-			writer.WriteLine('}');
 		}
 
 		public sealed override bool HasMember(string name)

--- a/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportField.cs
+++ b/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportField.cs
@@ -8,14 +8,13 @@ namespace uTinyRipper.Converters.Script
 	{
 		public abstract void Init(IScriptExportManager manager);
 
-		public void Export(TextWriter writer, int intent)
+		public void Export(CodeWriter writer)
 		{
 			foreach (ScriptExportAttribute attribute in Attributes)
 			{
-				attribute.Export(writer, intent);
+				attribute.Export(writer);
 			}
 
-			writer.WriteIndent(intent);
 			writer.Write("{0} ", Keyword);
 			if (IsNew)
 			{
@@ -26,11 +25,10 @@ namespace uTinyRipper.Converters.Script
 			writer.WriteLine("{0} {1};", typeName, Name);
 		}
 
-		public void ExportEnum(TextWriter writer, int intent)
+		public void ExportEnum(CodeWriter writer)
 		{
 			if (Type.IsEnum)
 			{
-				writer.WriteIndent(intent);
 				writer.WriteLine("{0} = {1},", Name, Constant);
 			}
 			else

--- a/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportMethod.cs
+++ b/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportMethod.cs
@@ -8,38 +8,34 @@ namespace uTinyRipper.Converters.Script
 	{
 		public abstract void Init(IScriptExportManager manager);
 
-		public void Export(TextWriter writer, int intent)
+		public void Export(CodeWriter writer)
 		{
-			writer.WriteIndent(intent);
 			string returnTypeName = ReturnType.GetTypeNestedName(DeclaringType);
 			writer.Write("{0} override {1} {2}(", Keyword, returnTypeName, Name);
 			for (int i = 0; i < Parameters.Count; i++)
 			{
 				ScriptExportParameter parameter = Parameters[i];
-				parameter.Export(writer, intent);
+				parameter.Export(writer);
 				if (i < Parameters.Count - 1)
 				{
 					writer.Write(", ");
 				}
 			}
 			writer.WriteLine(")");
-			writer.WriteIndent(intent);
-			writer.WriteLine("{");
-			foreach (ScriptExportParameter parameter in Parameters)
+			using (writer.IndentBrackets())
 			{
-				if (parameter.ByRef == ScriptExportParameter.ByRefType.Out)
+				foreach (ScriptExportParameter parameter in Parameters)
 				{
-					writer.WriteIndent(intent + 1);
-					writer.WriteLine("{0} = default({1});", parameter.Name, parameter.Type.GetTypeNestedName(DeclaringType));
+					if (parameter.ByRef == ScriptExportParameter.ByRefType.Out)
+					{
+						writer.WriteLine("{0} = default({1});", parameter.Name, parameter.Type.GetTypeNestedName(DeclaringType));
+					}
+				}
+				if (ReturnType.TypeName != MonoUtils.CVoidName)
+				{
+					writer.WriteLine("return default({0});", returnTypeName);
 				}
 			}
-			if (ReturnType.TypeName != MonoUtils.CVoidName)
-			{
-				writer.WriteIndent(intent + 1);
-				writer.WriteLine("return default({0});", returnTypeName);
-			}
-			writer.WriteIndent(intent);
-			writer.WriteLine("}");
 		}
 
 		public void GetUsedNamespaces(ICollection<string> namespaces)

--- a/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportParameter.cs
+++ b/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportParameter.cs
@@ -18,7 +18,7 @@ namespace uTinyRipper.Converters.Script
 
 		public abstract void Init(IScriptExportManager manager);
 
-		public void Export(TextWriter writer, int intent)
+		public void Export(CodeWriter writer)
 		{
 			switch (ByRef)
 			{

--- a/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportProperty.cs
+++ b/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportProperty.cs
@@ -7,35 +7,31 @@ namespace uTinyRipper.Converters.Script
 	{
 		public abstract void Init(IScriptExportManager manager);
 
-		public void Export(TextWriter writer, int intent)
+		public void Export(CodeWriter writer)
 		{
-			writer.WriteIndent(intent);
 			string sharedKeyword = PropertyKeyword;
 			writer.WriteLine("{0} override {1} {2}", sharedKeyword, Type.GetTypeNestedName(DeclaringType), Name);
-			writer.WriteIndent(intent);
-			writer.WriteLine("{");
 
-			if (HasGetter)
+			using (writer.IndentBrackets())
 			{
-				writer.WriteIndent(intent + 1);
-				if (GetKeyword != sharedKeyword)
+				if (HasGetter)
 				{
-					writer.WriteLine("{0} ", GetKeyword);
-				}
-				writer.WriteLine("get {{ return default({0}); }}", Type.NestedName);
-			}
-			if (HasSetter)
-			{
-				writer.WriteIndent(intent + 1);
-				if (SetKeyword != sharedKeyword)
-				{
-					writer.WriteLine("{0} ", SetKeyword);
-				}
-				writer.WriteLine("set {}");
-			}
+					if (GetKeyword != sharedKeyword)
+					{
+						writer.WriteLine("{0} ", GetKeyword);
+					}
 
-			writer.WriteIndent(intent);
-			writer.WriteLine("}");
+					writer.WriteLine("get {{ return default({0}); }}", Type.NestedName);
+				}
+				if (HasSetter)
+				{
+					if (SetKeyword != sharedKeyword)
+					{
+						writer.WriteLine("{0} ", SetKeyword);
+					}
+					writer.WriteLine("set {}");
+				}
+			}
 		}
 
 		public void GetUsedNamespaces(ICollection<string> namespaces)

--- a/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportType.cs
+++ b/uTinyRipperCore/Converters/Project/Exporters/Script/Elements/ScriptExportType.cs
@@ -8,81 +8,78 @@ namespace uTinyRipper.Converters.Script
 	{
 		public abstract void Init(IScriptExportManager manager);
 
-		public void Export(TextWriter writer)
+		public void ExportAsFile(CodeWriter writer)
 		{
 			ExportUsings(writer);
 			if (Namespace == string.Empty)
 			{
-				Export(writer, 0);
+				Export(writer);
 			}
 			else
 			{
 				writer.WriteLine("namespace {0}", Namespace);
-				writer.WriteLine('{');
-				Export(writer, 1);
-				writer.WriteLine('}');
+				using (writer.IndentBrackets())
+				{
+					Export(writer);
+				}
 			}
 		}
 
-		public virtual void Export(TextWriter writer, int intent)
+		public virtual void Export(CodeWriter writer)
 		{
 			if (IsSerializable)
 			{
-				writer.WriteIndent(intent);
 				writer.WriteLine("[{0}]", ScriptExportAttribute.SerializableName);
 			}
 
-			writer.WriteIndent(intent);
 			writer.Write("{0} {1} {2}", Keyword, IsStruct ? "struct" : "class", TypeName);
 			if (Base != null && !SerializableType.IsBasic(Base.Namespace, Base.NestedName))
 			{
 				writer.Write(" : {0}", Base.GetTypeNestedName(DeclaringType));
 			}
 			writer.WriteLine();
-			writer.WriteIndent(intent++);
-			writer.WriteLine('{');
 
-			foreach (ScriptExportType nestedType in NestedTypes)
+			using (writer.IndentBrackets())
 			{
-				nestedType.Export(writer, intent);
-				writer.WriteLine();
-			}
+				foreach (ScriptExportType nestedType in NestedTypes)
+				{
+					nestedType.Export(writer);
+					writer.WriteLine();
+				}
 
-			foreach (ScriptExportEnum nestedEnum in NestedEnums)
-			{
-				nestedEnum.Export(writer, intent);
-				writer.WriteLine();
-			}
+				foreach (ScriptExportEnum nestedEnum in NestedEnums)
+				{
+					nestedEnum.Export(writer);
+					writer.WriteLine();
+				}
 
-			foreach (ScriptExportDelegate @delegate in Delegates)
-			{
-				@delegate.Export(writer, intent);
-			}
-			if (Delegates.Count > 0)
-			{
-				writer.WriteLine();
-			}
+				foreach (ScriptExportDelegate @delegate in Delegates)
+				{
+					@delegate.Export(writer);
+				}
+				if (Delegates.Count > 0)
+				{
+					writer.WriteLine();
+				}
 
-			foreach (ScriptExportMethod method in Methods)
-			{
-				method.Export(writer, intent);
-				writer.WriteLine();
+				foreach (ScriptExportMethod method in Methods)
+				{
+					method.Export(writer);
+					writer.WriteLine();
+				}
+				foreach (ScriptExportProperty property in Properties)
+				{
+					property.Export(writer);
+				}
+				if (Properties.Count > 0)
+				{
+					writer.WriteLine();
+				}
+				foreach (ScriptExportField field in Fields)
+				{
+					field.Export(writer);
+				}
 			}
-			foreach (ScriptExportProperty property in Properties)
-			{
-				property.Export(writer, intent);
-			}
-			if (Properties.Count > 0)
-			{
-				writer.WriteLine();
-			}
-			foreach (ScriptExportField field in Fields)
-			{
-				field.Export(writer, intent);
-			}
-
-			writer.WriteIndent(--intent);
-			writer.WriteLine('}');
 		}
 
 		public virtual void GetTypeNamespaces(ICollection<string> namespaces)
@@ -177,7 +174,7 @@ namespace uTinyRipper.Converters.Script
 			DeclaringType.m_nestedDelegates.Add((ScriptExportDelegate)this);
 		}
 
-		private void ExportUsings(TextWriter writer)
+		private void ExportUsings(CodeWriter writer)
 		{
 			HashSet<string> namespaces = new HashSet<string>();
 			GetUsedNamespaces(namespaces);

--- a/uTinyRipperCore/Converters/Project/Exporters/Script/ScriptExportManager.cs
+++ b/uTinyRipperCore/Converters/Project/Exporters/Script/ScriptExportManager.cs
@@ -128,7 +128,10 @@ namespace uTinyRipper.Converters.Script
 			{
 				using (StreamWriter writer = new InvariantStreamWriter(fileStream, new UTF8Encoding(false)))
 				{
-					exportType.Export(writer);
+					using (CodeWriter code = new CodeWriter(writer))
+					{
+						exportType.ExportAsFile(code);
+					}
 				}
 			}
 			AddExportedType(exportType);

--- a/uTinyRipperCore/IO/CodeWriter.cs
+++ b/uTinyRipperCore/IO/CodeWriter.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+
+namespace uTinyRipper
+{
+	public class CodeWriter : IndentedTextWriter
+	{
+		public CodeWriter(TextWriter inner, string indent = "\t") : base(inner, indent)
+		{
+		}
+	}
+}

--- a/uTinyRipperCore/IO/IndentedTextWriter.cs
+++ b/uTinyRipperCore/IO/IndentedTextWriter.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace uTinyRipper
 {
 
 	/// <summary>
 	/// A TextWriter that automatically indents text
-	/// Additionally it will unify <c>\r</c> , <c>\n</c> and <see cref="TextWriter.NewLine"/>
 	/// </summary>
 	public class IndentedTextWriter : TextWriter
 	{
@@ -23,32 +23,176 @@ namespace uTinyRipper
 			m_indentLevel++;
 			return new DisposableHelper(() => m_indentLevel--);
 		}
-		
+
 		public IDisposable DisableIndent(bool indentCurrent = false)
 		{
 			if (indentCurrent)
 			{
-				MaybeWriteIndent();
+				MaybeIndent();
 			}
 
 			m_disableIndent++;
 			return new DisposableHelper(() => m_disableIndent--);
 		}
-
-		public void MaybeWriteIndent()
+		
+		private void MaybeIndent()
 		{
 			if (m_indentPending)
 			{
 				m_indentPending = false;
-
 				if (m_disableIndent == 0)
 				{
 					for (int i = 0; i < m_indentLevel; i++)
 					{
-						Write(m_indent);
+						m_inner.Write(m_indent);
 					}
 				}
 			}
+		}
+
+		private async Task MaybeIndentAsync()
+		{
+			if (m_indentPending)
+			{
+				m_indentPending = false;
+				if (m_disableIndent == 0)
+				{
+					for (int i = 0; i < m_indentLevel; i++)
+					{
+						await m_inner.WriteAsync(m_indent);
+					}
+				}
+			}
+		}
+
+		public override void Flush()
+		{
+			m_inner.Flush();
+		}
+
+		public override async Task FlushAsync()
+		{
+			await m_inner.FlushAsync();
+		}
+
+		public override void Write(bool value)
+		{
+			MaybeIndent();
+			m_inner.Write(value);
+		}
+
+		public override void Write(char value)
+		{
+			MaybeIndent();
+			m_inner.Write(value);
+		}
+
+		public override void Write(char[] buffer)
+		{
+			MaybeIndent();
+			m_inner.Write(buffer);
+		}
+
+		public override void Write(char[] buffer, int index, int count)
+		{
+			MaybeIndent();
+			m_inner.Write(buffer, index, count);
+		}
+
+		public override void Write(decimal value)
+		{
+			MaybeIndent();
+			m_inner.Write(value);
+		}
+
+		public override void Write(double value)
+		{
+			MaybeIndent();
+			m_inner.Write(value);
+		}
+
+		public override void Write(int value)
+		{
+			MaybeIndent();
+			m_inner.Write(value);
+		}
+
+		public override void Write(long value)
+		{
+			MaybeIndent();
+			m_inner.Write(value);
+		}
+
+		public override void Write(object value)
+		{
+			MaybeIndent();
+			m_inner.Write(value);
+		}
+
+		public override void Write(float value)
+		{
+			MaybeIndent();
+			m_inner.Write(value);
+		}
+
+		public override void Write(string value)
+		{
+			MaybeIndent();
+			m_inner.Write(value);
+		}
+
+		public override void Write(string format, object arg0)
+		{
+			MaybeIndent();
+			m_inner.Write(format, arg0);
+		}
+
+		public override void Write(string format, object arg0, object arg1)
+		{
+			MaybeIndent();
+			m_inner.Write(format, arg0, arg1);
+		}
+
+		public override void Write(string format, object arg0, object arg1, object arg2)
+		{
+			MaybeIndent();
+			m_inner.Write(format, arg0, arg1, arg2);
+		}
+
+		public override void Write(string format, params object[] arg)
+		{
+			MaybeIndent();
+			m_inner.Write(format, arg);
+		}
+
+		public override void Write(uint value)
+		{
+			MaybeIndent();
+			m_inner.Write(value);
+		}
+
+		public override void Write(ulong value)
+		{
+			MaybeIndent();
+			m_inner.Write(value);
+		}
+
+		public override async Task WriteAsync(char value)
+		{
+			await MaybeIndentAsync();
+			await m_inner.WriteAsync(value);
+		}
+
+		public override async Task WriteAsync(char[] buffer, int index, int count)
+		{
+			await MaybeIndentAsync();
+			await m_inner.WriteAsync(buffer, index, count);
+		}
+
+		public override async Task WriteAsync(string value)
+		{
+			await MaybeIndentAsync();
+			await m_inner.WriteAsync(value);
 		}
 
 		public override void WriteLine()
@@ -57,7 +201,161 @@ namespace uTinyRipper
 			m_indentPending = true;
 		}
 
-		public override void Write(char value)
+		public override void WriteLine(bool value)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(value);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(char value)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(value);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(char[] buffer)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(buffer);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(char[] buffer, int index, int count)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(buffer, index, count);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(decimal value)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(value);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(double value)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(value);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(int value)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(value);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(long value)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(value);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(object value)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(value);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(float value)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(value);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(string value)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(value);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(string format, object arg0)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(format, arg0);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(string format, object arg0, object arg1)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(format, arg0, arg1);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(string format, object arg0, object arg1, object arg2)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(format, arg0, arg1, arg2);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(string format, params object[] arg)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(format, arg);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(uint value)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(value);
+			m_indentPending = true;
+		}
+
+		public override void WriteLine(ulong value)
+		{
+			MaybeIndent();
+			m_inner.WriteLine(value);
+			m_indentPending = true;
+		}
+
+		public override async Task WriteLineAsync()
+		{
+			await m_inner.WriteLineAsync();
+			m_indentPending = true;
+		}
+
+		public override async Task WriteLineAsync(char value)
+		{
+			await MaybeIndentAsync();
+			await m_inner.WriteLineAsync(value);
+			m_indentPending = true;
+		}
+
+		public override async Task WriteLineAsync(char[] buffer, int index, int count)
+		{
+			await MaybeIndentAsync();
+			await m_inner.WriteLineAsync(buffer, index, count);
+			m_indentPending = true;
+		}
+
+		public override async Task WriteLineAsync(string value)
+		{
+			await MaybeIndentAsync();
+			await base.WriteLineAsync(value);
+			m_indentPending = true;
+		}
+
+		public void WriteIndentedFull(string value)
+		{
+			foreach (char c in value)
+			{
+				WriteCharWithState(c);
+			}
+		}
+
+		public void WriteCharWithState(char value)
 		{
 			if (CoreNewLine[m_newLineState] == value)
 			{
@@ -83,7 +381,7 @@ namespace uTinyRipper
 				WriteLine();
 				m_newLineState = 0;
 			}
-			else if (m_newLineState == 0) 
+			else if (m_newLineState == 0)
 			{
 				if (value == '\r' || value == '\n')
 				{
@@ -91,16 +389,16 @@ namespace uTinyRipper
 				}
 				else
 				{
-					MaybeWriteIndent();
+					MaybeIndent();
 					m_inner.Write(value);
 				}
 			}
 		}
-		
+
 		public override Encoding Encoding => m_inner.Encoding;
 
 		public override IFormatProvider FormatProvider => m_inner.FormatProvider;
-		
+
 		protected override void Dispose(bool disposing)
 		{
 			m_inner.Dispose();

--- a/uTinyRipperCore/IO/IndentedTextWriter.cs
+++ b/uTinyRipperCore/IO/IndentedTextWriter.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace uTinyRipper
+{
+
+	/// <summary>
+	/// A TextWriter that automatically indents text
+	/// Additionally it will unify <c>\r</c> , <c>\n</c> and <see cref="TextWriter.NewLine"/>
+	/// </summary>
+	public class IndentedTextWriter : TextWriter
+	{
+		public IndentedTextWriter(TextWriter inner, string indent = "\t")
+		{
+			m_inner = inner ?? throw new ArgumentNullException(nameof(inner));
+			m_indent = indent ?? throw new ArgumentNullException(nameof(indent));
+			base.NewLine = m_inner.NewLine;
+		}
+
+		public IDisposable Indent()
+		{
+			m_indentLevel++;
+			return new DisposableHelper(() => m_indentLevel--);
+		}
+		
+		public IDisposable DisableIndent(bool indentCurrent = false)
+		{
+			if (indentCurrent)
+			{
+				MaybeWriteIndent();
+			}
+
+			m_disableIndent++;
+			return new DisposableHelper(() => m_disableIndent--);
+		}
+
+		public void MaybeWriteIndent()
+		{
+			if (m_indentPending)
+			{
+				m_indentPending = false;
+
+				if (m_disableIndent == 0)
+				{
+					for (int i = 0; i < m_indentLevel; i++)
+					{
+						Write(m_indent);
+					}
+				}
+			}
+		}
+
+		public override void WriteLine()
+		{
+			m_inner.WriteLine();
+			m_indentPending = true;
+		}
+
+		public override void Write(char value)
+		{
+			if (CoreNewLine[m_newLineState] == value)
+			{
+				m_newLineState++;
+			}
+			else if (m_newLineState != 0)
+			{
+				if (CoreNewLine[m_newLineState - 1] == '\r' || CoreNewLine[m_newLineState - 1] == '\n')
+				{
+					m_inner.Write(CoreNewLine, 0, m_newLineState - 1);
+					WriteLine();
+				}
+				else
+				{
+					m_inner.Write(CoreNewLine, 0, m_newLineState);
+				}
+
+				m_newLineState = 0;
+			}
+
+			if (m_newLineState == CoreNewLine.Length)
+			{
+				WriteLine();
+				m_newLineState = 0;
+			}
+			else if (m_newLineState == 0) 
+			{
+				if (value == '\r' || value == '\n')
+				{
+					WriteLine();
+				}
+				else
+				{
+					MaybeWriteIndent();
+					m_inner.Write(value);
+				}
+			}
+		}
+		
+		public override Encoding Encoding => m_inner.Encoding;
+
+		public override IFormatProvider FormatProvider => m_inner.FormatProvider;
+		
+		protected override void Dispose(bool disposing)
+		{
+			m_inner.Dispose();
+			base.Dispose(disposing);
+		}
+
+		private readonly TextWriter m_inner;
+		private readonly string m_indent;
+		private int m_disableIndent;
+		private int m_indentLevel;
+		private int m_newLineState;
+		private bool m_indentPending;
+	}
+}
+

--- a/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedPass.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedPass.cs
@@ -38,63 +38,59 @@ namespace uTinyRipper.Classes.Shaders
 
 		public void Export(ShaderWriter writer)
 		{
-			writer.WriteIndent(2);
 			writer.Write("{0} ", Type.ToString());
 
 			if (Type == SerializedPassType.UsePass)
 			{
-				writer.Write("\"{0}\"\n", UseName);
+				writer.WriteLine("\"{0}\"", UseName);
 			}
 			else
 			{
-				writer.Write("{\n");
-
-				if (Type == SerializedPassType.GrabPass)
+				using (writer.IndentBrackets())
 				{
-					if (TextureName.Length > 0)
+					if (Type == SerializedPassType.GrabPass)
 					{
-						writer.WriteIndent(3);
-						writer.Write("\"{0}\"\n", TextureName);
+						if (TextureName.Length > 0)
+						{
+							writer.WriteLine("\"{0}\"", TextureName);
+						}
 					}
-				}
-				else if (Type == SerializedPassType.Pass)
-				{
-					State.Export(writer);
+					else if (Type == SerializedPassType.Pass)
+					{
+						State.Export(writer);
 
-					if ((ProgramMask & ShaderType.Vertex.ToProgramMask()) != 0)
-					{
-						ProgVertex.Export(writer, ShaderType.Vertex);
-					}
-					if ((ProgramMask & ShaderType.Fragment.ToProgramMask()) != 0)
-					{
-						ProgFragment.Export(writer, ShaderType.Fragment);
-					}
-					if ((ProgramMask & ShaderType.Geometry.ToProgramMask()) != 0)
-					{
-						ProgGeometry.Export(writer, ShaderType.Geometry);
-					}
-					if ((ProgramMask & ShaderType.Hull.ToProgramMask()) != 0)
-					{
-						ProgHull.Export(writer, ShaderType.Hull);
-					}
-					if ((ProgramMask & ShaderType.Domain.ToProgramMask()) != 0)
-					{
-						ProgDomain.Export(writer, ShaderType.Domain);
-					}
-					if ((ProgramMask & ShaderType.RayTracing.ToProgramMask()) != 0)
-					{
-						ProgDomain.Export(writer, ShaderType.RayTracing);
-					}
+						if ((ProgramMask & ShaderType.Vertex.ToProgramMask()) != 0)
+						{
+							ProgVertex.Export(writer, ShaderType.Vertex);
+						}
+						if ((ProgramMask & ShaderType.Fragment.ToProgramMask()) != 0)
+						{
+							ProgFragment.Export(writer, ShaderType.Fragment);
+						}
+						if ((ProgramMask & ShaderType.Geometry.ToProgramMask()) != 0)
+						{
+							ProgGeometry.Export(writer, ShaderType.Geometry);
+						}
+						if ((ProgramMask & ShaderType.Hull.ToProgramMask()) != 0)
+						{
+							ProgHull.Export(writer, ShaderType.Hull);
+						}
+						if ((ProgramMask & ShaderType.Domain.ToProgramMask()) != 0)
+						{
+							ProgDomain.Export(writer, ShaderType.Domain);
+						}
+						if ((ProgramMask & ShaderType.RayTracing.ToProgramMask()) != 0)
+						{
+							ProgDomain.Export(writer, ShaderType.RayTracing);
+						}
 
 #warning HasInstancingVariant?
+					}
+					else
+					{
+						throw new NotSupportedException($"Unsupported pass type {Type}");
+					}
 				}
-				else
-				{
-					throw new NotSupportedException($"Unsupported pass type {Type}");
-				}
-
-				writer.WriteIndent(2);
-				writer.Write("}\n");
 			}
 		}
 

--- a/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedProgram.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedProgram.cs
@@ -14,15 +14,15 @@ namespace uTinyRipper.Classes.Shaders
 				return;
 			}
 
-			writer.WriteIndent(3);
-			writer.Write("Program \"{0}\" {{\n", type.ToProgramTypeString());
-			int tierCount = GetTierCount();
-			for (int i = 0; i < SubPrograms.Length; i++)
+			writer.Write("Program \"{0}\" ", type.ToProgramTypeString());
+			using (writer.IndentBrackets())
 			{
-				SubPrograms[i].Export(writer, type, tierCount > 1);
+				int tierCount = GetTierCount();
+				for (int i = 0; i < SubPrograms.Length; i++)
+				{
+					SubPrograms[i].Export(writer, type, tierCount > 1);
+				}
 			}
-			writer.WriteIndent(3);
-			writer.Write("}\n");
 		}
 
 		private int GetTierCount()

--- a/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedProperties.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedProperties.cs
@@ -9,16 +9,16 @@ namespace uTinyRipper.Classes.Shaders
 			Props = reader.ReadAssetArray<SerializedProperty>();
 		}
 
-		public void Export(TextWriter writer)
+		public void Export(ShaderWriter writer)
 		{
-			writer.WriteIndent(1);
-			writer.Write("Properties {\n");
-			foreach(SerializedProperty prop in Props)
+			writer.Write("Properties ");
+			using (writer.IndentBrackets())
 			{
-				prop.Export(writer);
+				foreach (SerializedProperty prop in Props)
+				{
+					prop.Export(writer);
+				}
 			}
-			writer.WriteIndent(1);
-			writer.Write("}\n");
 		}
 
 		public SerializedProperty[] Props { get; set; }

--- a/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedProperty.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedProperty.cs
@@ -20,9 +20,8 @@ namespace uTinyRipper.Classes.Shaders
 			DefTexture.Read(reader);
 		}
 
-		public void Export(TextWriter writer)
+		public void Export(ShaderWriter writer)
 		{
-			writer.WriteIndent(2);
 			foreach(string attribute in Attributes)
 			{
 				writer.Write("[{0}] ", attribute);
@@ -133,7 +132,7 @@ namespace uTinyRipper.Classes.Shaders
 				default:
 					throw new NotSupportedException($"Serialized property type {Type} isn't supported");
 			}
-			writer.Write('\n');
+			writer.WriteLine();
 		}
 
 		public string Name { get; set; }

--- a/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedShader.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedShader.cs
@@ -16,28 +16,26 @@ namespace uTinyRipper.Classes.Shaders
 
 		public void Export(ShaderWriter writer)
 		{
-			writer.Write("Shader \"{0}\" {{\n", Name);
-
-			PropInfo.Export(writer);
-
-			for (int i = 0; i < SubShaders.Length; i++)
+			writer.Write("Shader \"{0}\" ", Name);
+			using (writer.IndentBrackets())
 			{
-				SubShaders[i].Export(writer);
-			}
+				PropInfo.Export(writer);
 
-			if (FallbackName.Length != 0)
-			{
-				writer.WriteIndent(1);
-				writer.Write("Fallback \"{0}\"\n", FallbackName);
-			}
+				for (int i = 0; i < SubShaders.Length; i++)
+				{
+					SubShaders[i].Export(writer);
+				}
 
-			if (CustomEditorName.Length != 0)
-			{
-				writer.WriteIndent(1);
-				writer.Write("CustomEditor \"{0}\"\n", CustomEditorName);
-			}
+				if (FallbackName.Length != 0)
+				{
+					writer.WriteLine("Fallback \"{0}\"", FallbackName);
+				}
 
-			writer.Write('}');
+				if (CustomEditorName.Length != 0)
+				{
+					writer.WriteLine("CustomEditor \"{0}\"", CustomEditorName);
+				}
+			}
 		}
 
 		public SerializedSubShader[] SubShaders { get; set; }

--- a/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedShaderRTBlendState.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedShaderRTBlendState.cs
@@ -15,11 +15,10 @@ namespace uTinyRipper.Classes.Shaders
 			ColMask.Read(reader);
 		}
 
-		public void Export(TextWriter writer, int index)
+		public void Export(ShaderWriter writer, int index)
 		{
 			if (!SrcBlendValue.IsOne() || !DestBlendValue.IsZero() || !SrcBlendAlphaValue.IsOne() || !DestBlendAlphaValue.IsZero())
 			{
-				writer.WriteIndent(3);
 				writer.Write("Blend ");
 				if(index != -1)
 				{
@@ -30,12 +29,11 @@ namespace uTinyRipper.Classes.Shaders
 				{
 					writer.Write(", {0} {1}", SrcBlendAlphaValue, DestBlendAlphaValue);
 				}
-				writer.Write('\n');
+				writer.WriteLine();
 			}
 
 			if(!BlendOpValue.IsAdd() || !BlendOpAlphaValue.IsAdd())
 			{
-				writer.WriteIndent(3);
 				writer.Write("BlendOp ");
 				if(index != -1)
 				{
@@ -46,12 +44,11 @@ namespace uTinyRipper.Classes.Shaders
 				{
 					writer.Write(", {0}", BlendOpAlphaValue);
 				}
-				writer.Write('\n');
+				writer.WriteLine();
 			}
 			
 			if(!ColMaskValue.IsRBGA())
 			{
-				writer.WriteIndent(3);
 				writer.Write("ColorMask ");
 				if (ColMaskValue.IsNone())
 				{
@@ -76,7 +73,7 @@ namespace uTinyRipper.Classes.Shaders
 						writer.Write(nameof(ColorMask.A));
 					}
 				}
-				writer.Write(" {0}\n", index);
+				writer.WriteLine(" {0}", index);
 			}
 		}
 

--- a/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedShaderState.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedShaderState.cs
@@ -53,19 +53,17 @@ namespace uTinyRipper.Classes.Shaders
 			reader.AlignStream();
 		}
 
-		public void Export(TextWriter writer)
+		public void Export(ShaderWriter writer)
 		{
 			if (Name != string.Empty)
 			{
-				writer.WriteIndent(3);
-				writer.Write("Name \"{0}\"\n", Name);
+				writer.WriteLine("Name \"{0}\"", Name);
 			}
 			if (LOD != 0)
 			{
-				writer.WriteIndent(3);
-				writer.Write("LOD {0}\n", LOD);
+				writer.WriteLine("LOD {0}", LOD);
 			}
-			Tags.Export(writer, 3);
+			Tags.Export(writer);
 			
 			RtBlend0.Export(writer, RtSeparateBlend ? 0 : -1);
 			RtBlend1.Export(writer, 1);
@@ -78,112 +76,97 @@ namespace uTinyRipper.Classes.Shaders
 
 			if (AlphaToMaskValue)
 			{
-				writer.WriteIndent(3);
-				writer.Write("AlphaToMask On\n");
+				writer.WriteLine("AlphaToMask On");
 			}
 
 			if (!ZClipValue.IsOn())
 			{
-				writer.WriteIndent(3);
-				writer.Write("ZClip {0}\n", ZClipValue);
+				writer.WriteLine("ZClip {0}", ZClipValue);
 			}
 			if (!ZTestValue.IsLEqual() && !ZTestValue.IsNone())
 			{
-				writer.WriteIndent(3);
-				writer.Write("ZTest {0}\n", ZTestValue);
+				writer.WriteLine("ZTest {0}", ZTestValue);
 			}
 			if (!ZWriteValue.IsOn())
 			{
-				writer.WriteIndent(3);
-				writer.Write("ZWrite {0}\n", ZWriteValue);
+				writer.WriteLine("ZWrite {0}", ZWriteValue);
 			}
 			if (!CullingValue.IsBack())
 			{
-				writer.WriteIndent(3);
-				writer.Write("Cull {0}\n", CullingValue);
+				writer.WriteLine("Cull {0}", CullingValue);
 			}
 			if (!OffsetFactor.IsZero || !OffsetUnits.IsZero)
 			{
-				writer.WriteIndent(3);
-				writer.Write("Offset {0}, {1}\n", OffsetFactor.Val, OffsetUnits.Val);
+				writer.WriteLine("Offset {0}, {1}", OffsetFactor.Val, OffsetUnits.Val);
 			}
 
 			if (!StencilRef.IsZero || !StencilReadMask.IsMax || !StencilWriteMask.IsMax || !StencilOp.IsDefault || !StencilOpFront.IsDefault || !StencilOpBack.IsDefault)
 			{
-				writer.WriteIndent(3);
-				writer.Write("Stencil {\n");
-				if(!StencilRef.IsZero)
+				writer.Write("Stencil ");
+				using (writer.IndentBrackets())
 				{
-					writer.WriteIndent(4);
-					writer.Write("Ref {0}\n", StencilRef.Val);
+					if (!StencilRef.IsZero)
+					{
+						writer.WriteLine("Ref {0}", StencilRef.Val);
+					}
+					if (!StencilReadMask.IsMax)
+					{
+						writer.WriteLine("ReadMask {0}", StencilReadMask.Val);
+					}
+					if (!StencilWriteMask.IsMax)
+					{
+						writer.WriteLine("WriteMask {0}", StencilWriteMask.Val);
+					}
+					if (!StencilOp.IsDefault)
+					{
+						StencilOp.Export(writer, StencilType.Base);
+					}
+					if (!StencilOpFront.IsDefault)
+					{
+						StencilOpFront.Export(writer, StencilType.Front);
+					}
+					if (!StencilOpBack.IsDefault)
+					{
+						StencilOpBack.Export(writer, StencilType.Back);
+					}
 				}
-				if(!StencilReadMask.IsMax)
-				{
-					writer.WriteIndent(4);
-					writer.Write("ReadMask {0}\n", StencilReadMask.Val);
-				}
-				if(!StencilWriteMask.IsMax)
-				{
-					writer.WriteIndent(4);
-					writer.Write("WriteMask {0}\n", StencilWriteMask.Val);
-				}
-				if(!StencilOp.IsDefault)
-				{
-					StencilOp.Export(writer, StencilType.Base);
-				}
-				if(!StencilOpFront.IsDefault)
-				{
-					StencilOpFront.Export(writer, StencilType.Front);
-				}
-				if(!StencilOpBack.IsDefault)
-				{
-					StencilOpBack.Export(writer, StencilType.Back);
-				}
-				writer.WriteIndent(3);
-				writer.Write("}\n");
 			}
 			
 			if(!FogMode.IsUnknown() || !FogColor.IsZero || !FogDensity.IsZero || !FogStart.IsZero || !FogEnd.IsZero)
 			{
-				writer.WriteIndent(3);
-				writer.Write("Fog {\n");
-				if(!FogMode.IsUnknown())
+				writer.Write("Fog ");
+				using (writer.IndentBrackets())
 				{
-					writer.WriteIndent(4);
-					writer.Write("Mode {0}\n", FogMode);
+					if (!FogMode.IsUnknown())
+					{
+						writer.WriteLine("Mode {0}", FogMode);
+					}
+					if (!FogColor.IsZero)
+					{
+						writer.WriteLine("Color ({0},{1},{2},{3})",
+							FogColor.X.Val.ToString(CultureInfo.InvariantCulture),
+							FogColor.Y.Val.ToString(CultureInfo.InvariantCulture),
+							FogColor.Z.Val.ToString(CultureInfo.InvariantCulture),
+							FogColor.W.Val.ToString(CultureInfo.InvariantCulture));
+					}
+					if (!FogDensity.IsZero)
+					{
+						writer.WriteLine("Density {0}", FogDensity.Val.ToString(CultureInfo.InvariantCulture));
+					}
+					if (!FogStart.IsZero || !FogEnd.IsZero)
+					{
+						writer.WriteLine("Range {0}, {1}",
+							FogStart.Val.ToString(CultureInfo.InvariantCulture),
+							FogEnd.Val.ToString(CultureInfo.InvariantCulture));
+					}
 				}
-				if (!FogColor.IsZero)
-				{
-					writer.WriteIndent(4);
-					writer.Write("Color ({0},{1},{2},{3})\n",
-						FogColor.X.Val.ToString(CultureInfo.InvariantCulture),
-						FogColor.Y.Val.ToString(CultureInfo.InvariantCulture),
-						FogColor.Z.Val.ToString(CultureInfo.InvariantCulture),
-						FogColor.W.Val.ToString(CultureInfo.InvariantCulture));
-				}
-				if (!FogDensity.IsZero)
-				{
-					writer.WriteIndent(4);
-					writer.Write("Density {0}\n", FogDensity.Val.ToString(CultureInfo.InvariantCulture));
-				}
-				if (!FogStart.IsZero ||!FogEnd.IsZero)
-				{
-					writer.WriteIndent(4);
-					writer.Write("Range {0}, {1}\n",
-						FogStart.Val.ToString(CultureInfo.InvariantCulture),
-						FogEnd.Val.ToString(CultureInfo.InvariantCulture));
-				}
-				writer.WriteIndent(3);
-				writer.Write("}\n");
 			}
 
 			if(Lighting)
 			{
-				writer.WriteIndent(3);
-				writer.Write("Lighting {0}\n", LightingValue);
+				writer.WriteLine("Lighting {0}", LightingValue);
 			}
-			writer.WriteIndent(3);
-			writer.Write("GpuProgramID {0}\n", GpuProgramID);
+			writer.WriteLine("GpuProgramID {0}", GpuProgramID);
 		}
 
 		public string Name { get; set; }

--- a/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedStencilOp.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedStencilOp.cs
@@ -12,16 +12,12 @@ namespace uTinyRipper.Classes.Shaders
 			Comp.Read(reader);
 		}
 
-		public void Export(TextWriter writer, StencilType type)
+		public void Export(ShaderWriter writer, StencilType type)
 		{
-			writer.WriteIndent(4);
-			writer.Write("Comp{0} {1}\n", type.ToSuffixString(), CompValue);
-			writer.WriteIndent(4);
-			writer.Write("Pass{0} {1}\n", type.ToSuffixString(), PassValue);
-			writer.WriteIndent(4);
-			writer.Write("Fail{0} {1}\n", type.ToSuffixString(), FailValue);
-			writer.WriteIndent(4);
-			writer.Write("ZFail{0} {1}\n", type.ToSuffixString(), ZFailValue);
+			writer.WriteLine("Comp{0} {1}", type.ToSuffixString(), CompValue);
+			writer.WriteLine("Pass{0} {1}", type.ToSuffixString(), PassValue);
+			writer.WriteLine("Fail{0} {1}", type.ToSuffixString(), FailValue);
+			writer.WriteLine("ZFail{0} {1}", type.ToSuffixString(), ZFailValue);
 		}
 
 		public bool IsDefault => PassValue.IsKeep() && FailValue.IsKeep() && ZFailValue.IsKeep() && CompValue.IsAlways();

--- a/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedSubProgram.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedSubProgram.cs
@@ -72,7 +72,6 @@ namespace uTinyRipper.Classes.Shaders
 
 		public void Export(ShaderWriter writer, ShaderType type, bool isTier)
 		{
-			writer.WriteIndent(4);
 #warning TODO: convertion (DX to HLSL)
 			ShaderGpuProgramType programType = GetProgramType(writer.Version);
 			GPUPlatform graphicApi = programType.ToGPUPlatform(writer.Platform);
@@ -81,15 +80,13 @@ namespace uTinyRipper.Classes.Shaders
 			{
 				writer.Write("hw_tier{0} ", ShaderHardwareTier.ToString("00"));
 			}
-			writer.Write("\" {\n");
-			writer.WriteIndent(5);
-
-			int platformIndex = writer.Shader.Platforms.IndexOf(graphicApi);
-			writer.Shader.Blobs[platformIndex].SubPrograms[BlobIndex].Export(writer, type);
-
-			writer.Write('\n');
-			writer.WriteIndent(4);
-			writer.Write("}\n");
+			writer.Write("\" ");
+			using (writer.IndentBrackets())
+			{
+				int platformIndex = writer.Shader.Platforms.IndexOf(graphicApi);
+				writer.Shader.Blobs[platformIndex].SubPrograms[BlobIndex].Export(writer, type);
+				writer.WriteLine();
+			}
 		}
 
 		public ShaderGpuProgramType GetProgramType(Version version)

--- a/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedSubShader.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedSubShader.cs
@@ -11,20 +11,19 @@ namespace uTinyRipper.Classes.Shaders
 
 		public void Export(ShaderWriter writer)
 		{
-			writer.WriteIndent(1);
-			writer.Write("SubShader {\n");
-			if(LOD != 0)
+			writer.Write("SubShader ");
+			using (writer.IndentBrackets())
 			{
-				writer.WriteIndent(2);
-				writer.Write("LOD {0}\n", LOD);
+				if (LOD != 0)
+				{
+					writer.WriteLine("LOD {0}", LOD);
+				}
+				Tags.Export(writer);
+				for (int i = 0; i < Passes.Length; i++)
+				{
+					Passes[i].Export(writer);
+				}
 			}
-			Tags.Export(writer, 2);
-			for (int i = 0; i < Passes.Length; i++)
-			{
-				Passes[i].Export(writer);
-			}
-			writer.WriteIndent(1);
-			writer.Write("}\n");
 		}
 
 		public SerializedPass[] Passes { get; set; }

--- a/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedTagMap.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/SerializedShader/SerializedTagMap.cs
@@ -12,17 +12,16 @@ namespace uTinyRipper.Classes.Shaders
 			m_tags.Read(reader);
 		}
 
-		public void Export(TextWriter writer, int intent)
+		public void Export(ShaderWriter writer)
 		{
 			if(Tags.Count != 0)
 			{
-				writer.WriteIndent(intent);
 				writer.Write("Tags { ");
-				foreach(var kvp in Tags)
+				foreach(KeyValuePair<string, string> kvp in Tags)
 				{
 					writer.Write("\"{0}\" = \"{1}\" ", kvp.Key, kvp.Value);
 				}
-				writer.Write("}\n");
+				writer.WriteLine("}");
 			}
 		}
 

--- a/uTinyRipperCore/Parser/Classes/Shader/Shader.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/Shader.cs
@@ -182,23 +182,29 @@ namespace uTinyRipper.Classes
 		{
 			if (IsSerialized(container.Version))
 			{
-				using (ShaderWriter writer = new ShaderWriter(stream, this, exporterInstantiator))
+				using (InvariantStreamWriter streamWriter = new InvariantStreamWriter(stream, new UTF8Encoding(false), 4096, true))
 				{
-					ParsedForm.Export(writer);
+					using (ShaderWriter writer = new ShaderWriter(streamWriter, this, exporterInstantiator))
+					{
+						ParsedForm.Export(writer);
+					}
 				}
 			}
 			else if (HasBlob(container.Version))
 			{
-				using (ShaderWriter writer = new ShaderWriter(stream, this, exporterInstantiator))
+				using (InvariantStreamWriter streamWriter = new InvariantStreamWriter(stream, new UTF8Encoding(false), 4096, true))
 				{
-					string header = Encoding.UTF8.GetString(Script);
-					if (Blobs.Length == 0)
+					using (ShaderWriter writer = new ShaderWriter(streamWriter, this, exporterInstantiator))
 					{
-						writer.Write(header);
-					}
-					else
-					{
-						Blobs[0].Export(writer, header);
+						string header = Encoding.UTF8.GetString(Script);
+						if (Blobs.Length == 0)
+						{
+							writer.Write(header);
+						}
+						else
+						{
+							Blobs[0].Export(writer, header);
+						}
 					}
 				}
 			}

--- a/uTinyRipperCore/Parser/Classes/Shader/ShaderSubProgram.cs
+++ b/uTinyRipperCore/Parser/Classes/Shader/ShaderSubProgram.cs
@@ -320,8 +320,7 @@ namespace uTinyRipper.Classes.Shaders
 						writer.Write("\"{0}\" ", keyword);
 					}
 				}
-				writer.Write("}\n");
-				writer.WriteIndent(5);
+				writer.WriteLine("}");
 			}
 
 #warning TODO: convertion (DX to HLSL)
@@ -329,9 +328,7 @@ namespace uTinyRipper.Classes.Shaders
 			writer.Write("\"{0}", programType.ToProgramDataKeyword(writer.Platform, type));
 			if (ProgramData.Length > 0)
 			{
-				writer.Write("\n");
-				writer.WriteIndent(5);
-
+				writer.WriteLine();
 				writer.WriteShaderData(ref this);
 			}
 			writer.Write('"');

--- a/uTinyRipperCore/Parser/IO/ShaderWriter.cs
+++ b/uTinyRipperCore/Parser/IO/ShaderWriter.cs
@@ -7,10 +7,10 @@ using uTinyRipper.Converters.Shaders;
 
 namespace uTinyRipper
 {
-	public class ShaderWriter : InvariantStreamWriter
+	public class ShaderWriter : IndentedTextWriter
 	{
-		public ShaderWriter(Stream stream, Shader shader, Func<Version, GPUPlatform, ShaderTextExporter> exporterInstantiator) :
-			base(stream, new UTF8Encoding(false), 4096, true)
+		public ShaderWriter(TextWriter inner, Shader shader, Func<Version, GPUPlatform, ShaderTextExporter> exporterInstantiator) :
+			base(inner)
 		{
 			if(shader == null)
 			{

--- a/uTinyRipperCore/Utils/DisposableHelper.cs
+++ b/uTinyRipperCore/Utils/DisposableHelper.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace uTinyRipper
+{
+	/// <summary>
+	/// A helper that calls an action once when it is disposed
+	/// For use with <c>using</c> constructs
+	/// </summary>
+	public class DisposableHelper : IDisposable
+	{
+		public DisposableHelper(Action action)
+		{
+			m_action = action;
+		}
+
+		public void Dispose()
+		{
+			m_action?.Invoke();
+			m_action = null;
+		}
+
+		private Action m_action;
+	}
+}

--- a/uTinyRipperCore/Utils/Extensions/TextWriterExtensions.cs
+++ b/uTinyRipperCore/Utils/Extensions/TextWriterExtensions.cs
@@ -12,14 +12,6 @@ namespace uTinyRipper
 				writer.Write(@string[i]);
 			}
 		}
-
-		public static void WriteIndent(this TextWriter writer, int count)
-		{
-			for (int i = 0; i < count; i++)
-			{
-				writer.Write('\t');
-			}
-		}
 		
 		public static IDisposable IndentBrackets(this IndentedTextWriter writer)
 		{

--- a/uTinyRipperCore/Utils/Extensions/TextWriterExtensions.cs
+++ b/uTinyRipperCore/Utils/Extensions/TextWriterExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 
 namespace uTinyRipper
@@ -18,6 +19,17 @@ namespace uTinyRipper
 			{
 				writer.Write('\t');
 			}
+		}
+		
+		public static IDisposable IndentBrackets(this IndentedTextWriter writer)
+		{
+			writer.WriteLine("{");
+			IDisposable indent = writer.Indent();
+			return new DisposableHelper(() =>
+			{
+				indent.Dispose();
+				writer.WriteLine("}");
+			});
 		}
 	}
 }

--- a/uTinyRipperGUI/Exporters/Shader/DirectX/ShaderDXExporter.cs
+++ b/uTinyRipperGUI/Exporters/Shader/DirectX/ShaderDXExporter.cs
@@ -34,7 +34,7 @@ namespace uTinyRipperGUI.Exporters
 
 			D3DCompiler.D3DCompiler.D3DDisassemble(unmanagedPointer, (uint)dataLength, 0, null, out IDxcBlob disassembly);
 			string disassemblyText = GetStringFromBlob(disassembly);
-			writer.Write(disassemblyText);
+			writer.WriteIndentedFull(disassemblyText.Trim());
 
 			Marshal.FreeHGlobal(unmanagedPointer);
 		}

--- a/uTinyRipperGUI/Exporters/Shader/DirectX/ShaderDXExporter.cs
+++ b/uTinyRipperGUI/Exporters/Shader/DirectX/ShaderDXExporter.cs
@@ -34,7 +34,7 @@ namespace uTinyRipperGUI.Exporters
 
 			D3DCompiler.D3DCompiler.D3DDisassemble(unmanagedPointer, (uint)dataLength, 0, null, out IDxcBlob disassembly);
 			string disassemblyText = GetStringFromBlob(disassembly);
-			ExportListing(writer, disassemblyText);
+			writer.Write(disassemblyText);
 
 			Marshal.FreeHGlobal(unmanagedPointer);
 		}

--- a/uTinyRipperGUI/Exporters/Shader/ShaderHLSLccExporter.cs
+++ b/uTinyRipperGUI/Exporters/Shader/ShaderHLSLccExporter.cs
@@ -43,7 +43,7 @@ namespace uTinyRipperGUI.Exporters
 						}
 						else
 						{
-							writer.Write(shader.Text);
+							writer.WriteIndentedFull(shader.Text.Trim());
 						}
 					}
 				}

--- a/uTinyRipperGUI/Exporters/Shader/ShaderHLSLccExporter.cs
+++ b/uTinyRipperGUI/Exporters/Shader/ShaderHLSLccExporter.cs
@@ -43,7 +43,7 @@ namespace uTinyRipperGUI.Exporters
 						}
 						else
 						{
-							ExportListing(writer, shader.Text);
+							writer.Write(shader.Text);
 						}
 					}
 				}

--- a/uTinyRipperGUI/Exporters/Shader/ShaderVulkanExporter.cs
+++ b/uTinyRipperGUI/Exporters/Shader/ShaderVulkanExporter.cs
@@ -58,7 +58,7 @@ namespace uTinyRipperGUI.Exporters
 						decodedStream.Position = 0;
 						Module module = Module.ReadFrom(decodedStream);
 						string listing = m_disassembler.Disassemble(module, DisassemblyOptions.Default);
-						ExportListing(writer, listing);
+						writer.Write(listing);
 					}
 					else
 					{

--- a/uTinyRipperGUI/Exporters/Shader/ShaderVulkanExporter.cs
+++ b/uTinyRipperGUI/Exporters/Shader/ShaderVulkanExporter.cs
@@ -42,7 +42,7 @@ namespace uTinyRipperGUI.Exporters
 			}
 		}
 
-		private void ExportSnippet(TextWriter writer, Stream stream, int offset, int size)
+		private void ExportSnippet(ShaderWriter writer, Stream stream, int offset, int size)
 		{
 			using (PartialStream snippetStream = new PartialStream(stream, offset, size))
 			{
@@ -58,7 +58,7 @@ namespace uTinyRipperGUI.Exporters
 						decodedStream.Position = 0;
 						Module module = Module.ReadFrom(decodedStream);
 						string listing = m_disassembler.Disassemble(module, DisassemblyOptions.Default);
-						writer.Write(listing);
+						writer.WriteIndentedFull(listing.Trim());
 					}
 					else
 					{


### PR DESCRIPTION
Introduced a `IndentedTextWriter` that takes care of indenting the output instead doing it manually everywhere.
Note: the the value of `IndentedTextWriter.NewLine` together with `\n` and `\r` is only what triggers the indentation, in either case it will be replaced by the value of `NewLine` in the inner writer.

This introduces the `CodeWriter` class which currently does nothing, but is a good place to add additional data for the individual export methods, such for settings or disambiguating type references, etc.
Script export output does not change.

Shader export now uses the system default line ending instead of always newline. This could now be changed in a single place. 