### PR TITLE
Core: add full Debug information

### DIFF
--- a/uTinyRipperCore/uTinyRipperCore.csproj
+++ b/uTinyRipperCore/uTinyRipperCore.csproj
@@ -15,6 +15,8 @@
     <DefineConstants>DEBUG;TRACE;NET_STANDARD;UNIVERSAL</DefineConstants>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <OutputPath>..\Bins\$(Configuration)\</OutputPath>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Virtual|AnyCPU'">


### PR DESCRIPTION
In `Debug` configuration, add `Full` Debugging Information.

The reason is: when setting a break-point in core, and running GUI project, the breakpoint is not `hit`.
