### PR TITLE
TextAsset-KeepExtension

### DIFF
--- a/uTinyRipperCore/Structure/ProjectCollection/Collections/AssetExportCollection.cs
+++ b/uTinyRipperCore/Structure/ProjectCollection/Collections/AssetExportCollection.cs
@@ -30,7 +30,7 @@ namespace uTinyRipper.Project
 			string fileName;
 			if (container.TryGetAssetPathFromAssets(Assets, out Object asset, out string assetPath))
 			{
-				string resourcePath = Path.Combine(dirPath, $"{assetPath}.{GetExportExtension(asset)}");
+				string resourcePath = Path.Combine(dirPath, AddExportExtension(assetPath, asset)); //$"{assetPath}.{GetExportExtension(asset)}"
 				subPath = Path.GetDirectoryName(resourcePath);
 				string resFileName = Path.GetFileName(resourcePath);
 #warning TODO: combine assets with the same res path into one big asset

--- a/uTinyRipperCore/Structure/ProjectCollection/Collections/ExportCollection.cs
+++ b/uTinyRipperCore/Structure/ProjectCollection/Collections/ExportCollection.cs
@@ -85,7 +85,7 @@ namespace uTinyRipper.Project
 				DirectoryUtils.CreateVirtualDirectory(path);
 			}
 
-			string fullName = $"{name}.{GetExportExtension(asset)}";
+			string fullName = AddExportExtension(name, asset);//$"{name}.{GetExportExtension(asset)}"
 			string uniqueName = FileUtils.GetUniqueName(path, fullName, FileUtils.MaxFileNameLength - MetaExtension.Length);
 			string filePath = Path.Combine(path, uniqueName);
 			AssetExporter.Export(container, asset, filePath);
@@ -114,7 +114,7 @@ namespace uTinyRipper.Project
 			}
 			fileName = FileNameRegex.Replace(fileName, string.Empty);
 
-			fileName = $"{fileName}.{GetExportExtension(asset)}";
+			fileName = AddExportExtension(fileName, asset);//$"{fileName}.{GetExportExtension(asset)}"
 			return GetUniqueFileName(dirPath, fileName);
 		}
 
@@ -126,6 +126,12 @@ namespace uTinyRipper.Project
 		protected virtual string GetExportExtension(Object asset)
 		{
 			return asset.ExportExtension;
+		}
+
+		protected virtual string AddExportExtension(string assetPath, Object asset)
+		{
+			var exportExtension = GetExportExtension(asset);
+			return string.IsNullOrWhiteSpace(exportExtension) ? assetPath : $"{assetPath}.{exportExtension}";
 		}
 
 		public abstract IAssetExporter AssetExporter { get; }

--- a/uTinyRipperCore/Structure/ProjectCollection/Collections/TextAssetExportCollection.cs
+++ b/uTinyRipperCore/Structure/ProjectCollection/Collections/TextAssetExportCollection.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using uTinyRipper.Classes;
 using uTinyRipper.Converters;
 
@@ -5,6 +6,9 @@ namespace uTinyRipper.Project
 {
 	public sealed class TextAssetExportCollection : AssetExportCollection
 	{
+
+		public static bool KeepExistingExtension { get; set; } = true;
+
 		public TextAssetExportCollection(IAssetExporter assetExporter, TextAsset asset) :
 			base(assetExporter, asset)
 		{
@@ -12,7 +16,8 @@ namespace uTinyRipper.Project
 
 		protected override string GetExportExtension(Object asset)
 		{
-			return "bytes";
+			//if the asset already has an extension then don't add the default extension
+			return KeepExistingExtension && asset is TextAsset textAsset && !string.IsNullOrEmpty(Path.GetExtension(textAsset.Name)) ? string.Empty : "bytes";
 		}
 	}
 }


### PR DESCRIPTION
If a TextAsset already has an extension, don't add the default `.bytes` extension.

May be turned off via the `bool TextAssetExportCollection.KeepExistingExtension` flag.