### PR TITLE
fix logic bug in HumanoidMuscleType.cs

### DIFF
--- a/uTinyRipperCore/Parser/Classes/AnimationClip/HumanoidMuscleType.cs
+++ b/uTinyRipperCore/Parser/Classes/AnimationClip/HumanoidMuscleType.cs
@@ -76,9 +76,8 @@ namespace uTinyRipper.Classes.AnimationClips
 			}
 			if(_this < HumanoidMuscleType.Last)
 			{
-				const int TDoFSize = (int)TDoFBoneType.Last;
 				int delta = _this - HumanoidMuscleType.TDoFBones;
-				TDoFBoneType tdof = (TDoFBoneType)(delta / TDoFSize);
+				TDoFBoneType tdof = (TDoFBoneType)(delta / 3);
 				return $"{tdof.ToBoneType().ToAttributeString()}{GetTDoFTransformPostfix(delta % 3)}";
 			}
 			throw new ArgumentException(_this.ToString());


### PR DESCRIPTION
division by count is incorrect - you will never reach all types, that's why you should divide just by 3